### PR TITLE
Fix typos and add unit tests

### DIFF
--- a/ai_models/app/main.py
+++ b/ai_models/app/main.py
@@ -11,5 +11,5 @@ class TextIn(BaseModel):
 
 @app.post("/correct")
 def correct_text(data: TextIn):
-    result = model.correct_text(data.text)
+    result = model.correct(data.text)
     return {"corrected": result}

--- a/app/api/routes/analyze.py
+++ b/app/api/routes/analyze.py
@@ -5,7 +5,7 @@ from models.ocr_response import OCRResponse
 from services.postprocessor import StructuredPostProcessor
 
 service_name = "aws"  # "aws"
-refiener_type = "gpt"  # "gpt", "huggingface" or None
+refiner_type = "gpt"  # "gpt", "huggingface" or None
 
 router = APIRouter()
 
@@ -16,10 +16,10 @@ async def analyze_document(file: UploadFile = File(...)):
     
     service = get_ocr_service(service_name)
     raw_fields = await service.analyze(file)
-    if refiener_type is None:
+    if refiner_type is None:
         return {"fields": raw_fields}
     else:
-        processor = StructuredPostProcessor(refiner_type = "gpt")
+        processor = StructuredPostProcessor(refiner_type=refiner_type)
         processed_fields = processor.process(raw_fields["fields"])
 
         return {"fields": processed_fields}

--- a/app/interfaces/postprocessor.py
+++ b/app/interfaces/postprocessor.py
@@ -1,4 +1,4 @@
-# app/postprocessing/interfaces/postprocessor.py
+# app/interfaces/postprocessor.py
 
 from abc import ABC, abstractmethod
 from typing import Dict

--- a/tests/test_basic_cleaner.py
+++ b/tests/test_basic_cleaner.py
@@ -1,0 +1,21 @@
+import os
+import sys
+import pytest
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+sys.path.append(ROOT)
+sys.path.append(os.path.join(ROOT, 'app'))
+from app.services.field_correctors.basic_cleaner import BasicFieldCorrector
+
+bc = BasicFieldCorrector()
+
+@pytest.mark.parametrize('key,value,expected', [
+    ('email', ' TEST@EXAMPLE.COM ', 'test@example.com'),
+    ('correo', 'bademail.com', None),
+    ('teléfono', '55 123-45678', '5512345678'),
+    ('teléfono', '55 123-4567', None),
+    ('monto', '$1,234', '1234'),
+])
+def test_basic_cleaner(key, value, expected):
+    assert bc.correct(key, value) == expected
+


### PR DESCRIPTION
## Summary
- fix typo `refiner_type` handling in analyze route
- correct grammar corrector endpoint
- update postprocessor file path comment
- add tests for BasicFieldCorrector

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c557257dc8322b5bbbf64cf43370a