### PR TITLE
Improve Textract async flow and add tests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,21 @@
+# Example environment variables for OCR Form Processor
+# Copy this file to `.env` and adjust values for your environment.
+
+# OCR engine selection
+OCR_SERVICE=aws
+
+# AI refinement type: "gpt" or "huggingface"
+REFINER_TYPE=gpt
+
+# OpenAI credentials (required if using GPT refiner)
+OPENAI_API_KEY=your-openai-key
+OPENAI_MODEL=gpt-3.5-turbo
+
+# HuggingFace model to use when REFINER_TYPE=huggingface
+HF_MODEL_NAME=dreuxx26/Multilingual-grammar-Corrector-using-mT5-small
+
+# AWS settings for Textract and S3
+AWS_ACCESS_KEY_ID=your-access-key
+AWS_SECRET_ACCESS_KEY=your-secret-key
+AWS_REGION=us-east-2
+AWS_S3_BUCKET=ocr-bucket-pbt-devop

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .env
 .env.*
+!.env.example
 *.pem
 /models/
 **.DS_Store

--- a/app/interfaces/ocr_service.py
+++ b/app/interfaces/ocr_service.py
@@ -1,4 +1,6 @@
 # app/interfaces/ocr_service.py
+"""Base interface for OCR implementations."""
+
 from abc import ABC, abstractmethod
 from typing import Dict
 from fastapi import UploadFile

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -1,6 +1,7 @@
 fastapi
 uvicorn
 boto3
+aioboto3
 flask
 requests
 pydantic

--- a/app/services/ai_refiners/gpt_refiner.py
+++ b/app/services/ai_refiners/gpt_refiner.py
@@ -1,3 +1,5 @@
+"""GPT-based field refiner used to polish OCR results."""
+
 import openai
 import json
 import logging

--- a/app/services/ai_refiners/huggingface_refiner.py
+++ b/app/services/ai_refiners/huggingface_refiner.py
@@ -1,4 +1,5 @@
-# app/services/ai_refiners/huggingface_refiner.py
+"""HuggingFace based refiner used for grammar correction."""
+
 import logging
 logging.basicConfig(level=logging.INFO)
 

--- a/app/services/ocr/textract/textract_ocr.py
+++ b/app/services/ocr/textract/textract_ocr.py
@@ -1,18 +1,27 @@
-# app/services/aws_textract.py
-import magic
+"""Asynchronous wrapper around AWS Textract for OCR extraction.
+
+This service uploads the received file to S3 and launches a Textract analysis
+job. When the job finishes the detected blocks are post processed to extract
+key/value pairs. Using :mod:`aioboto3` prevents blocking the event loop while we
+wait for the Textract job to complete.
+"""
+
+import asyncio
 import time
+import magic
 from models.data_response import DataResponse
 from fastapi import UploadFile
 from interfaces.ocr_service import OCRService
 from services.storage.s3_uploader import S3Uploader
 from services.ocr.form_identifier import FormIdentifier
 from services.ocr.textract.textract_extractor import TextractFullExtractor
+import aioboto3
 
 class AWSTextractOCRService(OCRService):
-    
-    def __init__(self, region_name="us-east-2", bucket_name="ocr-bucket-pbt-devop"):
-        import boto3
-        self.client = boto3.client("textract", region_name=region_name)
+    """Service that orchestrates OCR extraction using AWS Textract."""
+
+    def __init__(self, region_name: str = "us-east-2", bucket_name: str = "ocr-bucket-pbt-devop"):
+        self.region = region_name
         self.bucket = bucket_name
         self.uploader = S3Uploader(bucket_name, region_name)
 
@@ -29,31 +38,33 @@ class AWSTextractOCRService(OCRService):
         # Subir archivo a S3
         self.uploader.upload_file(contents, s3_key)
 
-        if is_pdf:
-            start_response = self.client.start_document_analysis(
-                DocumentLocation={"S3Object": {"Bucket": self.bucket, "Name": s3_key}},
-                FeatureTypes=["FORMS"]
-            )
-            job_id = start_response["JobId"]
+        async with aioboto3.client("textract", region_name=self.region) as client:
+            if is_pdf:
+                start_response = await client.start_document_analysis(
+                    DocumentLocation={"S3Object": {"Bucket": self.bucket, "Name": s3_key}},
+                    FeatureTypes=["FORMS"]
+                )
+                job_id = start_response["JobId"]
 
-            status = "IN_PROGRESS"
-            tries = 0
-            while status == "IN_PROGRESS" and tries < 20:
-                time.sleep(3)
-                result = self.client.get_document_analysis(JobId=job_id)
-                status = result["JobStatus"]
-                tries += 1
+                status = "IN_PROGRESS"
+                tries = 0
+                result = None
+                while status == "IN_PROGRESS" and tries < 20:
+                    await asyncio.sleep(3)
+                    result = await client.get_document_analysis(JobId=job_id)
+                    status = result["JobStatus"]
+                    tries += 1
 
-            if status != "SUCCEEDED":
-                raise RuntimeError(f"Textract job failed with status: {status}")
+                if status != "SUCCEEDED":
+                    raise RuntimeError(f"Textract job failed with status: {status}")
 
-            blocks = result.get("Blocks", [])
-        else:
-            result = self.client.analyze_document(
-                Document={"Bytes": contents},
-                FeatureTypes=["FORMS"]
-            )
-            blocks = result.get("Blocks", [])
+                blocks = result.get("Blocks", []) if result else []
+            else:
+                result = await client.analyze_document(
+                    Document={"Bytes": contents},
+                    FeatureTypes=["FORMS"]
+                )
+                blocks = result.get("Blocks", [])
 
         # Detectar tipo de formulario
         form_type = FormIdentifier.identify_form(blocks) or "desconocido"

--- a/app/services/postprocessors/postprocessor.py
+++ b/app/services/postprocessors/postprocessor.py
@@ -1,3 +1,5 @@
+"""Helpers to post-process OCR results into structured data."""
+
 import logging
 from models.data_response import DataResponse
 from interfaces.postprocessor import PostProcessor

--- a/tests/test_factories.py
+++ b/tests/test_factories.py
@@ -1,0 +1,57 @@
+import os
+import sys
+from pathlib import Path
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "app"))
+import types
+sys.modules.setdefault("magic", types.SimpleNamespace(from_buffer=lambda *a, **k: "application/pdf"))
+
+class _DummyClient:
+    def put_object(self, **kwargs):
+        pass
+    def delete_object(self, **kwargs):
+        pass
+
+def _dummy_client(service, *a, **k):
+    return _DummyClient()
+
+sys.modules.setdefault("boto3", types.SimpleNamespace(client=_dummy_client))
+sys.modules.setdefault("aioboto3", types.SimpleNamespace(client=_dummy_client))
+sys.modules.setdefault("openai", types.ModuleType("openai"))
+sys.modules.setdefault(
+    "transformers",
+    types.SimpleNamespace(pipeline=lambda *a, **k: lambda *args, **kwargs: [])
+)
+
+from services.ocr.factory import get_ocr_service
+from services.ai_refiners.factory import get_ai_refiner
+from services.ocr.textract.textract_ocr import AWSTextractOCRService
+from services.ai_refiners.gpt_refiner import GPTRefiner
+from services.ai_refiners.huggingface_refiner import HuggingFaceRefiner
+
+
+def test_get_ocr_service_default():
+    service = get_ocr_service("aws")
+    assert isinstance(service, AWSTextractOCRService)
+
+
+def test_get_ocr_service_unknown():
+    with pytest.raises(NotImplementedError):
+        get_ocr_service("unknown")
+
+
+def test_get_ai_refiner_gpt(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "test")
+    refiner = get_ai_refiner("gpt")
+    assert isinstance(refiner, GPTRefiner)
+
+
+def test_get_ai_refiner_huggingface():
+    refiner = get_ai_refiner("huggingface")
+    assert isinstance(refiner, HuggingFaceRefiner)
+
+
+def test_get_ai_refiner_invalid():
+    with pytest.raises(ValueError):
+        get_ai_refiner("invalid")


### PR DESCRIPTION
## Summary
- provide an example `.env` file
- document modules and interfaces
- refactor Textract service to use aioboto3 and asyncio
- update requirements with `aioboto3`
- add factory tests
- ignore `.env` but keep `.env.example`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c7e8d52bc8322b8b01a85cc65492f