### PR TITLE
Fix alias normalization and cleanup

### DIFF
--- a/app/services/field_correctors/alias_mapper.py
+++ b/app/services/field_correctors/alias_mapper.py
@@ -2,21 +2,34 @@
 
 import yaml
 from typing import Dict, List
+from services.utils.normalization import normalize_key
 
 class AliasMapper:
     def __init__(self, alias_file: str):
         with open(alias_file, encoding="utf-8") as f:
-            self.aliases = yaml.safe_load(f)
+            raw = yaml.safe_load(f) or {}
+        self.aliases = {
+            normalize_key(k): [normalize_key(a) for a in v]
+            for k, v in raw.items()
+        }
+
+    def _normalize_fields(self, fields: Dict[str, str]) -> Dict[str, str]:
+        return {normalize_key(k): v for k, v in fields.items()}
 
     def get(self, fields: Dict[str, str], key: str, default="") -> str:
-        for alias in self.aliases.get(key, []):
-            if alias in fields:
-                return fields[alias].strip()
+        fields_norm = self._normalize_fields(fields)
+        key_norm = normalize_key(key)
+        for alias in self.aliases.get(key_norm, []):
+            if alias in fields_norm:
+                return fields_norm[alias].strip()
         return default
 
     def get_checked(self, fields: Dict[str, str], options: List[str]) -> str:
+        fields_norm = self._normalize_fields(fields)
         for option in options:
-            value = self.get(fields, option).lower()
-            if value in {"[x]", "x", "si", "sí"}:
-                return option
+            option_norm = normalize_key(option)
+            for alias in self.aliases.get(option_norm, []):
+                value = fields_norm.get(alias, "").lower()
+                if value in {"[x]", "x", "si", "sí"}:
+                    return option
         return ""

--- a/app/services/field_correctors/aliases/banorte_credito.yaml
+++ b/app/services/field_correctors/aliases/banorte_credito.yaml
@@ -175,6 +175,24 @@ numero_identificacion:
   - numero de identificacion
   - numero_identificacion
 
+nacimiento_dia:
+  - Día de nacimiento
+  - nacimiento dia
+  - fecha de nacimiento dia
+  - nacimiento_dia
+
+nacimiento_mes:
+  - Mes de nacimiento
+  - nacimiento mes
+  - fecha de nacimiento mes
+  - nacimiento_mes
+
+nacimiento_año:
+  - Año de nacimiento
+  - nacimiento año
+  - fecha de nacimiento año
+  - nacimiento_año
+
 domicilio.calle:
   - Domicilio (Calle y número exterior e interior)
   - Domicilio (calle y número exterior e interior)
@@ -263,6 +281,11 @@ nombre_jefe:
   - Nombre y puesto del jefe inmediato
   - nombre y puesto del jefe inmediato
   - nombre_jefe
+
+antiguedad_meses:
+  - Antigüedad meses
+  - tiempo en el empleo
+  - antiguedad_meses
 
 tipo_ingreso.asalariado:
   - Asalariado

--- a/app/services/field_correctors/basic_cleaner.py
+++ b/app/services/field_correctors/basic_cleaner.py
@@ -8,6 +8,8 @@ from services.utils.normalization import normalize_key
 class BasicFieldCorrector(FieldCorrector):
     def correct(self, key: str, value: str) -> Optional[str]:
         value = value.strip()
+        if value.upper() == "VALUE_NOT_FOUND":
+            return None
         if not value or value.lower() in ["$", "0", "00", "000", "n/a", "na", "none", "--"]:
             return None
 

--- a/tests/test_alias_mapper.py
+++ b/tests/test_alias_mapper.py
@@ -1,0 +1,43 @@
+import sys
+from pathlib import Path
+import types
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "app"))
+
+alias_data = {
+    "campo_prueba": ["Campo Prueba", "campo.prueba", "cám po prueba"],
+    "check_option": ["Opción"],
+}
+
+def dummy_init(self, alias_file):
+    from services.utils.normalization import normalize_key
+    self.aliases = {
+        normalize_key(k): [normalize_key(a) for a in v]
+        for k, v in alias_data.items()
+    }
+
+@pytest.fixture
+def alias_cls(monkeypatch):
+    monkeypatch.setitem(sys.modules, "yaml", types.SimpleNamespace(safe_load=lambda f: {}))
+    from services.field_correctors.alias_mapper import AliasMapper
+    monkeypatch.setattr(AliasMapper, "__init__", dummy_init)
+    return AliasMapper
+
+
+def test_alias_mapper_normalization_get(alias_cls):
+    mapper = alias_cls(None)
+    fields = {"Campo Prueba": "valor"}
+    assert mapper.get(fields, "campo_prueba") == "valor"
+
+
+def test_alias_mapper_normalization_checked(alias_cls):
+    mapper = alias_cls(None)
+    fields = {"Opción": "X"}
+    assert mapper.get_checked(fields, ["check_option"]) == "check_option"
+
+
+def test_basic_cleaner_placeholder():
+    from services.field_correctors.basic_cleaner import BasicFieldCorrector
+    cleaner = BasicFieldCorrector()
+    assert cleaner.correct("any", "VALUE_NOT_FOUND") is None

--- a/tests/test_postprocessor.py
+++ b/tests/test_postprocessor.py
@@ -8,6 +8,7 @@ sys.modules.setdefault("yaml", types.SimpleNamespace(safe_load=lambda f: {}))
 
 from services.postprocessors.form_postprocessor.banorte_credito import BanorteCreditoPostProcessor
 from services.field_correctors import alias_mapper
+from services.utils.normalization import normalize_key
 
 alias_data = {
     "folio": ["folio"],
@@ -17,7 +18,10 @@ alias_data = {
 }
 
 def dummy_init(self, alias_file):
-    self.aliases = alias_data
+    self.aliases = {
+        normalize_key(k): [normalize_key(a) for a in v]
+        for k, v in alias_data.items()
+    }
 
 alias_mapper.AliasMapper.__init__ = dummy_init
 


### PR DESCRIPTION
## Summary
- normalize aliases and incoming field names in `AliasMapper`
- skip Textract placeholder values in `BasicFieldCorrector`
- extend Banorte credito alias list for birth date and employment fields
- adjust postprocessor tests for alias normalization
- add new tests covering alias handling and placeholder cleanup

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ce4b5c6448322939831a90397f991