### PR TITLE
Improve field extraction from Textract

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,6 @@ python web/app.py
 
 Luego abrir `http://localhost:5000` en el navegador para cargar un documento.
 
+
+### Mejoras recientes
+- Se agregó detección de pares clave/valor cuando la clave termina en ':' y el valor se encuentra en la siguiente línea.

--- a/app/services/ocr/textract/textract_extractor.py
+++ b/app/services/ocr/textract/textract_extractor.py
@@ -23,6 +23,7 @@ class TextractFullExtractor:
         """Extrae y normaliza los campos detectados por Textract."""
         self._extract_kv_pairs()
         self._add_inline_pairs()
+        self._add_colon_split_pairs()
         self._extract_consecutive_fields()
         self._extract_checkboxes()
         return self.field_dict
@@ -41,6 +42,18 @@ class TextractFullExtractor:
                 key_norm = normalize_key(key)
                 if key and key_norm not in self.field_dict:
                     self.field_dict[key_norm] = value
+
+    def _add_colon_split_pairs(self):
+        for idx, block in enumerate(self.lines[:-1]):
+            text = block.get("Text", "").strip()
+            if text.endswith(":"):
+                next_text = self.lines[idx + 1].get("Text", "").strip()
+                if next_text and ":" not in next_text:
+                    key = text[:-1].strip()
+                    if key:
+                        key_norm = normalize_key(key)
+                        if key_norm not in self.field_dict:
+                            self.field_dict[key_norm] = next_text
 
     def _build_word_map(self) -> Dict[str, str]:
         word_map = {}


### PR DESCRIPTION
## Summary
- improve TextractFullExtractor to pick up `key:` lines whose value is on the next line
- document the new capability in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684cf9bbe65c8322883a1961f83a9e84