### PR TITLE
Add Banorte credit postprocessor and normalization fix

### DIFF
--- a/app/services/postprocessors/form_postprocessor/__init__.py
+++ b/app/services/postprocessors/form_postprocessor/__init__.py
@@ -1,0 +1,3 @@
+from .banorte_credito import BanorteCreditoPostProcessor
+
+__all__ = ["BanorteCreditoPostProcessor"]

--- a/app/services/postprocessors/form_postprocessor/banorte_credito.py
+++ b/app/services/postprocessors/form_postprocessor/banorte_credito.py
@@ -1,0 +1,37 @@
+from services.postprocessors.generic_postprocessor import GenericPostProcessor
+
+
+class BanorteCreditoPostProcessor(GenericPostProcessor):
+    """Postprocesador especializado para formularios de crédito Banorte."""
+
+    CHECKLIST_MAP = {
+        "12": "plazo_de_credito",
+        "24": "plazo_de_credito",
+        "36": "plazo_de_credito",
+        "48": "plazo_de_credito",
+        "60": "plazo_de_credito",
+        "femenino": "genero",
+        "masculino": "genero",
+        "soltero": "estado_civil",
+        "casado": "estado_civil",
+        "union_libre": "estado_civil",
+        "propia": "vivienda",
+        "rentada": "vivienda",
+        "hipotecada": "vivienda",
+        "asalariado": "tipo_de_empleo",
+        "honorarios": "tipo_de_empleo",
+        "si": "politicamente_expuesto",
+        "no": "politicamente_expuesto",
+    }
+
+    def process(self, raw_fields: dict) -> dict:
+        cleaned = super().process(raw_fields)
+        checklist = cleaned.get("checklist")
+        if isinstance(checklist, list):
+            labeled = {}
+            for key in checklist:
+                label = self.CHECKLIST_MAP.get(key)
+                if label:
+                    labeled[label] = key
+            cleaned["checklist"] = labeled
+        return cleaned

--- a/app/services/postprocessors/postprocessor_factory.py
+++ b/app/services/postprocessors/postprocessor_factory.py
@@ -1,6 +1,9 @@
 # Ruta: services/postprocessor_factory.py
 
 from services.postprocessors.generic_postprocessor import GenericPostProcessor
+from services.postprocessors.form_postprocessor import BanorteCreditoPostProcessor
 
 def get_postprocessor(form_type: str = None):
+    if form_type == "banorte_credito":
+        return BanorteCreditoPostProcessor()
     return GenericPostProcessor()

--- a/app/services/utils/normalization.py
+++ b/app/services/utils/normalization.py
@@ -6,6 +6,6 @@ def normalize_key(key: str) -> str:
     key = unicodedata.normalize('NFKD', key).encode('ascii', 'ignore').decode('ascii')
     key = key.lower()
     key = re.sub(r'\(.*?\)', '', key)
-    key = re.sub(r'[^a-z0-9 ]', '', key)
+    key = re.sub(r'[^a-z0-9 _]', '', key)
     key = re.sub(r'\s+', '_', key)
     return key.strip('_')

--- a/tests/test_factories.py
+++ b/tests/test_factories.py
@@ -29,6 +29,8 @@ from services.ai_refiners.factory import get_ai_refiner
 from services.ocr.textract.textract_ocr import AWSTextractOCRService
 from services.ai_refiners.gpt_refiner import GPTRefiner
 from services.ai_refiners.huggingface_refiner import HuggingFaceRefiner
+from services.postprocessors.postprocessor_factory import get_postprocessor
+from services.postprocessors.form_postprocessor.banorte_credito import BanorteCreditoPostProcessor
 
 
 def test_get_ocr_service_default():
@@ -55,3 +57,8 @@ def test_get_ai_refiner_huggingface():
 def test_get_ai_refiner_invalid():
     with pytest.raises(ValueError):
         get_ai_refiner("invalid")
+
+
+def test_get_postprocessor_banorte_credito():
+    processor = get_postprocessor("banorte_credito")
+    assert isinstance(processor, BanorteCreditoPostProcessor)

--- a/tests/test_normalization.py
+++ b/tests/test_normalization.py
@@ -1,0 +1,10 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "app"))
+
+from services.utils.normalization import normalize_key
+
+
+def test_normalize_key_preserves_underscore():
+    assert normalize_key('nombre_y_puesto') == 'nombre_y_puesto'

--- a/tests/test_postprocessor.py
+++ b/tests/test_postprocessor.py
@@ -4,6 +4,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "app"))
 
 from services.postprocessors.generic_postprocessor import GenericPostProcessor
+from services.postprocessors.form_postprocessor.banorte_credito import BanorteCreditoPostProcessor
 
 
 def test_generic_postprocessor():
@@ -21,3 +22,26 @@ def test_generic_postprocessor():
     assert result["apellido_paterno"] == "Perez"
     assert "casado" in result["checklist"]
     assert "12" in result["checklist"]
+
+def test_banorte_postprocessor_checklist():
+    processor = BanorteCreditoPostProcessor()
+    raw = {
+        "12": "[X]",
+        "24": "[X]",
+        "48": "[X]",
+        "Femenino": "[X]",
+        "Soltero": "[X]",
+        "Propia": "[X]",
+        "Asalariado": "[X]",
+        "No": "[X]",
+    }
+    result = processor.process(raw)
+    assert result["checklist"] == {
+        "plazo_de_credito": "48",
+        "genero": "femenino",
+        "estado_civil": "soltero",
+        "vivienda": "propia",
+        "tipo_de_empleo": "asalariado",
+        "politicamente_expuesto": "no",
+    }
+


### PR DESCRIPTION
## Summary
- keep underscores when normalizing field names
- add BanorteCreditoPostProcessor to label checklist options
- register the new postprocessor in the factory
- test normalization and factory behaviors
- test Banorte credit checklist processing
- extend credit term mapping for Banorte checklist

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684d06f320f88322993f054d9330d160