### PR TITLE
Fix generic field extraction and filter unchecked options

### DIFF
--- a/app/services/field_correctors/basic_cleaner.py
+++ b/app/services/field_correctors/basic_cleaner.py
@@ -12,7 +12,8 @@ class BasicFieldCorrector(FieldCorrector):
 
     def correct(self, key: str, value: str) -> Optional[str]:
         value = value.strip()
-        if value.upper() == "VALUE_NOT_FOUND":
+        value_upper = value.upper()
+        if value_upper in {"VALUE_NOT_FOUND", "NOT_SELECTED", "[ ]", "[]"}:
             self.discarded_count += 1
             return None
         if not value or value.lower() in ["$", "0", "00", "000", "n/a", "na", "none", "--"]:

--- a/tests/test_basic_cleaner.py
+++ b/tests/test_basic_cleaner.py
@@ -9,3 +9,13 @@ from services.field_correctors.basic_cleaner import BasicFieldCorrector
 def test_basic_cleaner_placeholder():
     cleaner = BasicFieldCorrector()
     assert cleaner.correct("any", "VALUE_NOT_FOUND") is None
+
+
+def test_basic_cleaner_unchecked_box():
+    cleaner = BasicFieldCorrector()
+    assert cleaner.correct("any", "[ ]") is None
+
+
+def test_basic_cleaner_not_selected_keyword():
+    cleaner = BasicFieldCorrector()
+    assert cleaner.correct("any", "NOT_SELECTED") is None


### PR DESCRIPTION
## Summary
- allow `BasicFieldCorrector` to discard unchecked checkbox values
- make `_extract_consecutive_fields` independent from predefined field names
- test unchecked checkbox handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d0c15530c8322b34d21b07b21f7f2