### PR TITLE
Refine all fields in single call

### DIFF
--- a/app/services/postprocessors/postprocessor.py
+++ b/app/services/postprocessors/postprocessor.py
@@ -13,30 +13,31 @@ class StructuredPostProcessor(PostProcessor):
         self.corrector = get_postprocessor(form_type)
         self.refiner = get_ai_refiner(refiner_type)
 
+
     def _refine_section(self, section: str, content):
-        """
-        Intenta refinar una sección del formulario usando IA.
-        En caso de fallo, devuelve el contenido original.
-        """
+        """Refina una sección del formulario usando IA."""
         try:
             refined_result = self.refiner.refine({section: content})
             if isinstance(refined_result, dict) and section in refined_result:
                 return refined_result[section]
             elif isinstance(refined_result, dict) and refined_result:
                 return next(iter(refined_result.values()))
-            else:
-                return content
         except Exception as e:
-            logging.warning(f"[PostProcessor] Error al refinar sección '{section}': {e}")
-            return content
+            logging.warning(
+                f"[PostProcessor] Error al refinar sección '{section}': {e}"
+            )
+        return content
 
     def process(self) -> DataResponse:
         fields = self.data.get("fields")
         structured = self.corrector.process(fields)
 
-        for section, content in structured.items():
-            if isinstance(content, (dict, str)):
-                structured[section] = self._refine_section(section, content)
+        try:
+            refined = self.refiner.refine(structured)
+            if isinstance(refined, dict):
+                structured.update(refined)
+        except Exception as e:
+            logging.warning(f"[PostProcessor] Error al refinar campos: {e}")
 
         self.data["fields"] = structured
         return self.data

--- a/tests/test_structured_postprocessor.py
+++ b/tests/test_structured_postprocessor.py
@@ -1,0 +1,46 @@
+import sys
+import types
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "app"))
+sys.modules.setdefault("openai", types.ModuleType("openai"))
+sys.modules.setdefault(
+    "transformers",
+    types.SimpleNamespace(pipeline=lambda *a, **k: lambda *args, **kwargs: []),
+)
+
+from services.postprocessors.postprocessor import StructuredPostProcessor
+
+
+class DummyPostProcessor:
+    def process(self, fields):
+        return fields
+
+
+class DummyRefiner:
+    def __init__(self):
+        self.calls = []
+
+    def refine(self, fields):
+        self.calls.append(fields.copy())
+        return {k: v.upper() for k, v in fields.items()}
+
+
+def test_structured_postprocessor_single_refine(monkeypatch):
+    dummy_refiner = DummyRefiner()
+    monkeypatch.setattr(
+        "services.postprocessors.postprocessor.get_postprocessor",
+        lambda form_type: DummyPostProcessor(),
+    )
+    monkeypatch.setattr(
+        "services.postprocessors.postprocessor.get_ai_refiner",
+        lambda refiner_type: dummy_refiner,
+    )
+
+    data = {"fields": {"a": "x", "b": "y"}}
+    processor = StructuredPostProcessor(data, refiner_type="gpt")
+    result = processor.process()
+
+    assert result["fields"] == {"a": "X", "b": "Y"}
+    assert len(dummy_refiner.calls) == 1
+    assert dummy_refiner.calls[0] == {"a": "x", "b": "y"}


### PR DESCRIPTION
## Summary
- reduce GPT refiner calls by processing all fields at once
- add test covering new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d0da982408322a6e29ef6f792324c