### PR TITLE
Improve data cleaning for currency and checkboxes

### DIFF
--- a/app/services/field_correctors/basic_cleaner.py
+++ b/app/services/field_correctors/basic_cleaner.py
@@ -21,6 +21,9 @@ class BasicFieldCorrector(FieldCorrector):
             return None
 
         key_norm = normalize_key(key)
+        if len(key_norm) > 30 or len(key_norm.split('_')) > 5:
+            self.discarded_count += 1
+            return None
 
         # Corrección de emails
         if "correo" in key_norm or "email" in key_norm:
@@ -59,8 +62,12 @@ class BasicFieldCorrector(FieldCorrector):
 
         # Montos o ingresos
         elif "monto" in key_norm or "sueldo" in key_norm or "ingreso" in key_norm:
-            value = re.sub(r"[^\d]", "", value)
-            if not value:
+            # Remover símbolo de moneda y separadores de miles pero conservar los decimales
+            value = value.replace("$", "").replace(",", "").strip()
+            if not re.search(r"\d", value):
+                self.discarded_count += 1
+                return None
+            if not re.fullmatch(r"\d+(\.\d+)?", value):
                 self.discarded_count += 1
                 return None
 

--- a/app/services/postprocessors/generic_postprocessor.py
+++ b/app/services/postprocessors/generic_postprocessor.py
@@ -8,6 +8,8 @@ class GenericPostProcessor:
         """Aplica limpieza genérica a los campos extraídos."""
         cleaned = self.cleaner.transform(raw_fields)
         checklist = [k for k, v in cleaned.items() if isinstance(v, str) and v.lower() == "sí"]
+        for key in checklist:
+            cleaned.pop(key, None)
         if checklist:
             cleaned["checklist"] = checklist
         return cleaned

--- a/tests/test_basic_cleaner.py
+++ b/tests/test_basic_cleaner.py
@@ -19,3 +19,13 @@ def test_basic_cleaner_unchecked_box():
 def test_basic_cleaner_not_selected_keyword():
     cleaner = BasicFieldCorrector()
     assert cleaner.correct("any", "NOT_SELECTED") is None
+
+
+def test_basic_cleaner_currency():
+    cleaner = BasicFieldCorrector()
+    assert cleaner.correct("monto solicitado", "$100,000.00") == "100000.00"
+
+
+def test_basic_cleaner_discard_long_key():
+    cleaner = BasicFieldCorrector()
+    assert cleaner.correct("Aviso de Privacidad y Politica de Datos", "test") is None

--- a/tests/test_postprocessor.py
+++ b/tests/test_postprocessor.py
@@ -23,6 +23,14 @@ def test_generic_postprocessor():
     assert "casado" in result["checklist"]
     assert "12" in result["checklist"]
 
+
+def test_generic_postprocessor_removes_checkbox_fields():
+    processor = GenericPostProcessor()
+    raw = {"Soltero": "[X]", "Folio": "1"}
+    result = processor.process(raw)
+    assert "soltero" not in result
+    assert "soltero" in result["checklist"]
+
 def test_banorte_postprocessor_checklist():
     processor = BanorteCreditoPostProcessor()
     raw = {


### PR DESCRIPTION
## Summary
- avoid long field names in BasicFieldCorrector
- keep decimals in monetary fields
- drop checkbox fields after mapping to checklist
- extend tests for cleaner and postprocessor

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d0fedf2508322b81c6761cc5bff6a