### PR TITLE
Limit textract queries

### DIFF
--- a/app/services/aws_textract.py
+++ b/app/services/aws_textract.py
@@ -27,7 +27,10 @@ class AWSTextractOCRService(OCRService):
         except FileNotFoundError:
             queries = []
 
-        self.queries = queries
+        # Textract permite un máximo de 30 consultas por petición. El dataset
+        # incluye 33, por lo que limitamos la lista para evitar errores de
+        # "InvalidParameterException" al llamar a StartDocumentAnalysis.
+        self.queries = queries[:30]
 
     async def analyze(self, file: UploadFile) -> Dict:
         contents = await file.read()


### PR DESCRIPTION
## Summary
- cap Textract queries to avoid InvalidParameterException

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684da48085cc8322903a632e765c29c6