### PR TITLE
Add Textract layout parser and slash normalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,4 +36,7 @@ Luego abrir `http://localhost:5000` en el navegador para cargar un documento.
 
 
 ### Mejoras recientes
-- Se agregó detección de pares clave/valor cuando la clave termina en ':' y el valor se encuentra en la siguiente línea.
+- Los nombres de campo conservan los delimitadores "/" convirtiéndolos en "_".
+- El OCR de Textract agrupa las líneas manuscritas por secciones del formulario
+  Banorte utilizando los encabezados impresos (información del crédito,
+  información personal, domicilio, empleo y referencias personales).

--- a/app/services/ocr/textract/banorte_layout_parser.py
+++ b/app/services/ocr/textract/banorte_layout_parser.py
@@ -1,0 +1,56 @@
+from typing import Dict, List
+from services.utils.normalization import normalize_key
+
+
+class BanorteLayoutParser:
+    """Layout parser specialized for Banorte personal credit forms."""
+
+    STOP_HEADERS = {"CLAUSULAS", "CONSENTIMIENTO"}
+
+    def __init__(self, blocks: List[Dict]):
+        self.blocks = blocks or []
+
+    def _iter_lines(self) -> List[Dict]:
+        lines = [b for b in self.blocks if b.get("BlockType") == "LINE"]
+        return sorted(
+            lines,
+            key=lambda b: (
+                b.get("Page", 1),
+                b.get("Geometry", {}).get("BoundingBox", {}).get("Top", 0),
+                b.get("Geometry", {}).get("BoundingBox", {}).get("Left", 0),
+            ),
+        )
+
+    def _is_stop_header(self, text: str) -> bool:
+        return text.strip().upper() in self.STOP_HEADERS
+
+    def parse(self) -> Dict[str, List[str]]:
+        sections: Dict[str, List[str]] = {}
+        current_section = None
+        page = 1
+
+        for line in self._iter_lines():
+            text = line.get("Text", "").strip()
+            if not text:
+                continue
+
+            if line.get("Page", 1) != page:
+                current_section = None
+                page = line.get("Page", 1)
+
+            if line.get("TextType") != "HANDWRITING":
+                upper = text.upper()
+                if upper == "REFERENCIAS PERSONALES":
+                    current_section = normalize_key(text)
+                    sections.setdefault(current_section, [])
+                elif self._is_stop_header(text):
+                    current_section = None
+                elif "INFORMACION" in upper or "INFORMACIÓN" in upper or "DOMICILIO" in upper or "EMPLEO" in upper:
+                    current_section = normalize_key(text)
+                    sections.setdefault(current_section, [])
+                continue
+
+            if current_section:
+                sections.setdefault(current_section, []).append(text)
+
+        return {k: v for k, v in sections.items() if v}

--- a/app/services/ocr/textract/textract_layout_parser.py
+++ b/app/services/ocr/textract/textract_layout_parser.py
@@ -1,0 +1,40 @@
+from typing import Dict, List
+from services.utils.normalization import normalize_key
+
+class TextractLayoutParser:
+    """Parse Textract LINE blocks to group data by sections."""
+
+    def __init__(self, blocks: List[Dict]):
+        self.blocks = blocks or []
+
+    def _iter_lines(self):
+        lines = [b for b in self.blocks if b.get("BlockType") == "LINE"]
+        return sorted(lines, key=lambda b: (
+            b.get("Page", 1),
+            b.get("Geometry", {}).get("BoundingBox", {}).get("Top", 0),
+            b.get("Geometry", {}).get("BoundingBox", {}).get("Left", 0),
+        ))
+
+    def _is_header(self, text: str) -> bool:
+        return text.strip().upper() == "REFERENCIAS PERSONALES"
+
+    def _is_stop(self, text: str) -> bool:
+        return text.strip().upper() in {"CLAUSULAS", "CONSENTIMIENTO"}
+
+    def parse(self) -> Dict[str, List[str]]:
+        sections: Dict[str, List[str]] = {}
+        current = None
+        for line in self._iter_lines():
+            text = line.get("Text", "").strip()
+            if not text:
+                continue
+            if self._is_header(text):
+                current = normalize_key(text)
+                sections.setdefault(current, [])
+                continue
+            if self._is_stop(text):
+                current = None
+                continue
+            if current and line.get("TextType") == "HANDWRITING":
+                sections[current].append(text)
+        return sections

--- a/app/services/ocr/textract/textract_ocr.py
+++ b/app/services/ocr/textract/textract_ocr.py
@@ -16,6 +16,8 @@ from interfaces.ocr_service import OCRService
 from services.storage.s3_uploader import S3Uploader
 from services.ocr.form_identifier import FormIdentifier
 from services.ocr.textract.textract_extractor import TextractExtractor
+from services.ocr.textract.textract_layout_parser import TextractLayoutParser
+from services.ocr.textract.banorte_layout_parser import BanorteLayoutParser
 
 class AWSTextractOCRService(OCRService):
     
@@ -100,6 +102,16 @@ class AWSTextractOCRService(OCRService):
         # USAMOS el extractor
         extractor = TextractExtractor(blocks)
         fields = extractor.extract()
+        layout_parser = TextractLayoutParser(blocks)
+        sections = layout_parser.parse()
+        if sections:
+            fields.update(sections)
+
+        if form_type == "banorte_credito":
+            banorte_parser = BanorteLayoutParser(blocks)
+            extra_sections = banorte_parser.parse()
+            if extra_sections:
+                fields.update(extra_sections)
 
         return {
             "form_type": form_type,

--- a/app/services/utils/normalization.py
+++ b/app/services/utils/normalization.py
@@ -6,6 +6,7 @@ def normalize_key(key: str) -> str:
     key = unicodedata.normalize('NFKD', key).encode('ascii', 'ignore').decode('ascii')
     key = key.lower()
     key = re.sub(r'\(.*?\)', '', key)
+    key = key.replace('/', '_')
     key = re.sub(r'[^a-z0-9 _]', '', key)
     key = re.sub(r'\s+', '_', key)
     return key.strip('_')

--- a/tests/test_layout_parser.py
+++ b/tests/test_layout_parser.py
@@ -1,0 +1,47 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "app"))
+
+from services.ocr.textract.textract_layout_parser import TextractLayoutParser
+from services.ocr.textract.banorte_layout_parser import BanorteLayoutParser
+
+
+def test_layout_parser_collects_references():
+    blocks = [
+        {"Id": "1", "BlockType": "LINE", "Text": "REFERENCIAS PERSONALES", "Page": 1, "Geometry": {"BoundingBox": {"Top": 0.1, "Left": 0}}},
+        {"Id": "2", "BlockType": "LINE", "Text": "Juan Perez", "TextType": "HANDWRITING", "Page": 1, "Geometry": {"BoundingBox": {"Top": 0.2, "Left": 0}}},
+        {"Id": "3", "BlockType": "LINE", "Text": "Maria Lopez", "TextType": "HANDWRITING", "Page": 1, "Geometry": {"BoundingBox": {"Top": 0.3, "Left": 0}}},
+        {"Id": "4", "BlockType": "LINE", "Text": "CLAUSULAS", "Page": 1, "Geometry": {"BoundingBox": {"Top": 0.4, "Left": 0}}},
+    ]
+    parser = TextractLayoutParser(blocks)
+    sections = parser.parse()
+    assert sections["referencias_personales"] == ["Juan Perez", "Maria Lopez"]
+
+
+def test_banorte_layout_parser_sections():
+    blocks = [
+        {"Id": "1", "BlockType": "LINE", "Text": "INFORMACION DEL CREDITO", "Page": 1, "Geometry": {"BoundingBox": {"Top": 0.02, "Left": 0}}},
+        {"Id": "2", "BlockType": "LINE", "Text": "10000", "TextType": "HANDWRITING", "Page": 1, "Geometry": {"BoundingBox": {"Top": 0.05, "Left": 0}}},
+        {"Id": "3", "BlockType": "LINE", "Text": "12 meses", "TextType": "HANDWRITING", "Page": 1, "Geometry": {"BoundingBox": {"Top": 0.1, "Left": 0}}},
+        {"Id": "4", "BlockType": "LINE", "Text": "INFORMACION PERSONAL", "Page": 1, "Geometry": {"BoundingBox": {"Top": 0.15, "Left": 0}}},
+        {"Id": "5", "BlockType": "LINE", "Text": "Juan", "TextType": "HANDWRITING", "Page": 1, "Geometry": {"BoundingBox": {"Top": 0.2, "Left": 0}}},
+        {"Id": "6", "BlockType": "LINE", "Text": "Perez", "TextType": "HANDWRITING", "Page": 1, "Geometry": {"BoundingBox": {"Top": 0.25, "Left": 0}}},
+        {"Id": "7", "BlockType": "LINE", "Text": "DOMICILIO", "Page": 1, "Geometry": {"BoundingBox": {"Top": 0.3, "Left": 0}}},
+        {"Id": "8", "BlockType": "LINE", "Text": "Av Siempre Viva", "TextType": "HANDWRITING", "Page": 1, "Geometry": {"BoundingBox": {"Top": 0.35, "Left": 0}}},
+        {"Id": "9", "BlockType": "LINE", "Text": "Col Centro", "TextType": "HANDWRITING", "Page": 1, "Geometry": {"BoundingBox": {"Top": 0.4, "Left": 0}}},
+        {"Id": "10", "BlockType": "LINE", "Text": "EMPLEO", "Page": 1, "Geometry": {"BoundingBox": {"Top": 0.5, "Left": 0}}},
+        {"Id": "11", "BlockType": "LINE", "Text": "Empresa XYZ", "TextType": "HANDWRITING", "Page": 1, "Geometry": {"BoundingBox": {"Top": 0.55, "Left": 0}}},
+        {"Id": "12", "BlockType": "LINE", "Text": "Puesto ABC", "TextType": "HANDWRITING", "Page": 1, "Geometry": {"BoundingBox": {"Top": 0.6, "Left": 0}}},
+        {"Id": "13", "BlockType": "LINE", "Text": "REFERENCIAS PERSONALES", "Page": 2, "Geometry": {"BoundingBox": {"Top": 0.1, "Left": 0}}},
+        {"Id": "14", "BlockType": "LINE", "Text": "Carlos Diaz", "TextType": "HANDWRITING", "Page": 2, "Geometry": {"BoundingBox": {"Top": 0.2, "Left": 0}}},
+        {"Id": "15", "BlockType": "LINE", "Text": "555-1234", "TextType": "HANDWRITING", "Page": 2, "Geometry": {"BoundingBox": {"Top": 0.25, "Left": 0}}},
+        {"Id": "16", "BlockType": "LINE", "Text": "CLAUSULAS", "Page": 2, "Geometry": {"BoundingBox": {"Top": 0.4, "Left": 0}}},
+    ]
+    parser = BanorteLayoutParser(blocks)
+    sections = parser.parse()
+    assert sections["informacion_del_credito"] == ["10000", "12 meses"]
+    assert sections["informacion_personal"] == ["Juan", "Perez"]
+    assert sections["domicilio"] == ["Av Siempre Viva", "Col Centro"]
+    assert sections["empleo"] == ["Empresa XYZ", "Puesto ABC"]
+    assert sections["referencias_personales"] == ["Carlos Diaz", "555-1234"]

--- a/tests/test_normalization.py
+++ b/tests/test_normalization.py
@@ -8,3 +8,7 @@ from services.utils.normalization import normalize_key
 
 def test_normalize_key_preserves_underscore():
     assert normalize_key('nombre_y_puesto') == 'nombre_y_puesto'
+
+
+def test_normalize_key_slash_to_underscore():
+    assert normalize_key('estado/entidad') == 'estado_entidad'


### PR DESCRIPTION
## Summary
- normalize field keys without losing `/` characters
- include Textract layout parser to group handwritten sections
- use the layout parser in the AWS OCR service
- remove missing feature note from README
- test slash normalization and layout parser behaviour
- add parser for Banorte form layout
- refine layout parser to use printed headers

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684dbcf937988322845d102f73a1e857