### PR TITLE
Integrate structured field output

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,21 @@ Luego abrir `http://localhost:5000` en el navegador para cargar un documento.
 - El OCR de Textract agrupa las líneas manuscritas por secciones del formulario
   Banorte utilizando los encabezados impresos (información del crédito,
   información personal, domicilio, empleo y referencias personales).
+
+## Salida estructurada
+El postprocesador puede opcionalmente regresar un diccionario con secciones
+anidadas. Los campos se agrupan en `datos_personales`, `contacto`, `empleo` y
+`finanzas`, además de valores derivados de las casillas seleccionadas.
+
+Ejemplo:
+
+```json
+{
+  "datos_personales": {"nombre": "Juan"},
+  "contacto": {"telefono_de_casa": "5512345678"},
+  "empleo": {},
+  "finanzas": {"sueldo_mensual": "10000"},
+  "plazo_credito": "12",
+  "genero": "Femenino"
+}
+```

--- a/app/services/field_correctors/__init__.py
+++ b/app/services/field_correctors/__init__.py
@@ -1,0 +1,9 @@
+from .basic_cleaner import BasicFieldCorrector
+from .generic_cleaner import GenericFieldCleaner
+from .structured_cleaner import StructuredFieldCorrector
+
+__all__ = [
+    "BasicFieldCorrector",
+    "GenericFieldCleaner",
+    "StructuredFieldCorrector",
+]

--- a/app/services/field_correctors/structured_cleaner.py
+++ b/app/services/field_correctors/structured_cleaner.py
@@ -1,0 +1,129 @@
+# app/services/field_correctors/structured_cleaner.py
+
+import re
+from typing import Optional, Dict
+from interfaces.field_corrector import FieldCorrector
+from services.field_correctors.basic_cleaner import BasicFieldCorrector
+
+
+class StructuredFieldCorrector(FieldCorrector):
+    def __init__(self):
+        self.basic = BasicFieldCorrector()
+
+    def _clean_key(self, key: str) -> str:
+        return re.sub(r"[:\-\.]", "", key).strip().lower()
+
+    def _is_selected(self, value: str) -> bool:
+        value = value.lower()
+        return "[x]" in value or value in {"si", "sí", "x"}
+
+    def correct(self, key: str, value: str) -> Optional[str]:
+        return self.basic.correct(key, value)
+
+    def transform(self, raw_data: Dict[str, str]) -> Dict:
+        structured = {
+            "datos_personales": {},
+            "contacto": {},
+            "empleo": {},
+            "finanzas": {},
+            "plazo_credito": None,
+            "genero": None,
+            "estado_civil": None,
+            "regimen_matrimonial": None,
+            "tipo_propiedad": None,
+            "otros_ingresos": None,
+            "tipo_ingreso": None
+        }
+
+        plazos_detectados = set()
+        genero_detectado = None
+
+        for key, value in raw_data.items():
+            clean_key = self._clean_key(key)
+            corrected_value = self.correct(key, value)
+
+            if not clean_key or not corrected_value:
+                continue
+
+            # ✅ Selección de plazo de crédito
+            if clean_key in {"12", "18", "24", "36"} and self._is_selected(corrected_value):
+                plazos_detectados.add(clean_key)
+
+            # ✅ Género
+            elif "femenino" in clean_key and self._is_selected(corrected_value):
+                genero_detectado = "Femenino"
+            elif "masculino" in clean_key and self._is_selected(corrected_value):
+                genero_detectado = "Masculino"
+
+            # ✅ Estado civil
+            elif any(et in clean_key for et in ["soltero", "casado", "unión libre", "divorciado", "viudo"]):
+                if self._is_selected(corrected_value):
+                    structured["estado_civil"] = key.strip().split()[0]  # Ej. "Soltero"
+
+            # ✅ Régimen matrimonial
+            elif "sociedad conyugal" in clean_key and self._is_selected(corrected_value):
+                structured["regimen_matrimonial"] = "Sociedad Conyugal"
+            elif "separación de bienes" in clean_key and self._is_selected(corrected_value):
+                structured["regimen_matrimonial"] = "Separación de Bienes"
+
+            # ✅ Tipo de propiedad
+            elif "propia" in clean_key and self._is_selected(corrected_value):
+                structured["tipo_propiedad"] = "Propia"
+            elif "rentada" in clean_key and self._is_selected(corrected_value):
+                structured["tipo_propiedad"] = "Rentada"
+            elif "hipotecada" in clean_key and self._is_selected(corrected_value):
+                structured["tipo_propiedad"] = "Hipotecada"
+            elif "de familiares" in clean_key and self._is_selected(corrected_value):
+                structured["tipo_propiedad"] = "De familiares"
+
+            # ✅ Otros ingresos
+            elif "otros ingresos" in clean_key:
+                if "no" in clean_key and self._is_selected(corrected_value):
+                    structured["otros_ingresos"] = "No"
+                elif "sí" in clean_key and self._is_selected(corrected_value):
+                    structured["otros_ingresos"] = "Sí"
+
+            # ✅ Tipo de ingreso
+            elif "asalariado" in clean_key and self._is_selected(corrected_value):
+                structured["tipo_ingreso"] = "Asalariado"
+            elif "honorarios" in clean_key and self._is_selected(corrected_value):
+                structured["tipo_ingreso"] = "Honorarios"
+
+            # ✅ Sueldo mensual - limpiar símbolos
+            elif "sueldo mensual" in clean_key:
+                sueldo = re.sub(r"[^\d]", "", corrected_value)
+                structured["finanzas"]["sueldo_mensual"] = int(sueldo) if sueldo.isdigit() else None
+
+            # ✅ Agrupación general por categoría
+            elif any(x in clean_key for x in ["nombre", "apellido", "curp", "rfc"]):
+                structured["datos_personales"][clean_key] = corrected_value
+            elif any(x in clean_key for x in ["teléfono", "celular", "correo", "email"]):
+                structured["contacto"][clean_key] = corrected_value
+            elif any(x in clean_key for x in ["empresa", "puesto"]):
+                structured["empleo"][clean_key] = corrected_value
+            elif any(x in clean_key for x in ["monto", "nómina"]):
+                structured["finanzas"][clean_key] = corrected_value
+            else:
+                structured["datos_personales"][clean_key] = corrected_value
+
+        # ✅ Consolidación final
+        if plazos_detectados:
+            structured["plazo_credito"] = max(plazos_detectados, key=int)
+        else:
+            structured["plazo_credito"] = ""
+
+        if genero_detectado:
+            structured["genero"] = genero_detectado
+        else:
+            structured["genero"] = ""
+
+        # Valores por defecto para claves esperadas
+        for key in ["regimen_matrimonial", "otros_ingresos", "tipo_ingreso", "estado_civil", "tipo_propiedad"]:
+            if structured[key] is None:
+                structured[key] = ""
+
+        # Cast a string los valores del diccionario financiero
+        for k, v in structured["finanzas"].items():
+            structured["finanzas"][k] = str(v) if v is not None else ""
+
+        return structured

--- a/app/services/ocr/textract/textract_ocr.py
+++ b/app/services/ocr/textract/textract_ocr.py
@@ -85,6 +85,8 @@ class AWSTextractOCRService(OCRService):
                 blocks.extend(result.get("Blocks", []))
                 next_token = result.get("NextToken")
 
+        await run_in_threadpool(self.uploader.delete_file, s3_key)
+
         return {
             "blocks": blocks,
             "s3_path": s3_key,

--- a/app/services/postprocessors/postprocessor.py
+++ b/app/services/postprocessors/postprocessor.py
@@ -7,11 +7,12 @@ from services.postprocessors.postprocessor_factory import get_postprocessor
 from services.ai_refiners.factory import get_ai_refiner
 
 class StructuredPostProcessor(PostProcessor):
-    def __init__(self, data: DataResponse, refiner_type):
+    def __init__(self, data: DataResponse, refiner_type, structured_output: bool = False):
         self.data = data
         form_type = data.get("form_type", None)
-        self.corrector = get_postprocessor(form_type)
+        self.corrector = get_postprocessor(form_type, structured=structured_output)
         self.refiner = get_ai_refiner(refiner_type)
+        self.structured_output = structured_output
 
 
     def _refine_section(self, section: str, content):
@@ -32,12 +33,16 @@ class StructuredPostProcessor(PostProcessor):
         fields = self.data.get("fields")
         structured = self.corrector.process(fields)
 
-        try:
-            refined = self.refiner.refine(structured)
-            if isinstance(refined, dict):
-                structured.update(refined)
-        except Exception as e:
-            logging.warning(f"[PostProcessor] Error al refinar campos: {e}")
+        if self.structured_output:
+            for section, content in structured.items():
+                structured[section] = self._refine_section(section, content)
+        else:
+            try:
+                refined = self.refiner.refine(structured)
+                if isinstance(refined, dict):
+                    structured.update(refined)
+            except Exception as e:
+                logging.warning(f"[PostProcessor] Error al refinar campos: {e}")
 
         self.data["fields"] = structured
         return self.data

--- a/app/services/postprocessors/postprocessor_factory.py
+++ b/app/services/postprocessors/postprocessor_factory.py
@@ -2,8 +2,14 @@
 
 from services.postprocessors.generic_postprocessor import GenericPostProcessor
 from services.postprocessors.form_postprocessor import BanorteCreditoPostProcessor
+from services.postprocessors.structured_output_postprocessor import (
+    StructuredOutputPostProcessor,
+)
+def get_postprocessor(form_type: str | None = None, structured: bool = False):
+    """Return an appropriate postprocessor implementation."""
 
-def get_postprocessor(form_type: str = None):
+    if structured:
+        return StructuredOutputPostProcessor()
     if form_type == "banorte_credito":
         return BanorteCreditoPostProcessor()
     return GenericPostProcessor()

--- a/app/services/postprocessors/structured_output_postprocessor.py
+++ b/app/services/postprocessors/structured_output_postprocessor.py
@@ -1,0 +1,10 @@
+from services.field_correctors.structured_cleaner import StructuredFieldCorrector
+
+class StructuredOutputPostProcessor:
+    """Applies StructuredFieldCorrector directly to raw OCR fields."""
+
+    def __init__(self):
+        self.cleaner = StructuredFieldCorrector()
+
+    def process(self, raw_fields: dict, layout: dict | None = None) -> dict:
+        return self.cleaner.transform(raw_fields)

--- a/tests/test_ocr_cleanup.py
+++ b/tests/test_ocr_cleanup.py
@@ -1,0 +1,40 @@
+import sys
+import types
+import asyncio
+import pytest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "app"))
+
+from services.ocr.textract.textract_ocr import AWSTextractOCRService
+
+class DummyUploader:
+    def __init__(self):
+        self.deleted = False
+    def upload_file(self, *a, **k):
+        pass
+    def delete_file(self, *a, **k):
+        self.deleted = True
+
+class DummyClient:
+    def start_document_analysis(self, **kwargs):
+        return {"JobId": "1"}
+    def get_document_analysis(self, JobId=None, NextToken=None):
+        return {"JobStatus": "SUCCEEDED", "Blocks": [], "NextToken": None}
+
+async def _run_in_threadpool(func, *a, **k):
+    return func(*a, **k)
+
+@pytest.mark.asyncio
+async def test_s3_file_deleted(monkeypatch):
+    dummy_uploader = DummyUploader()
+    monkeypatch.setattr("services.ocr.textract.textract_ocr.S3Uploader", lambda *a, **k: dummy_uploader)
+    monkeypatch.setitem(sys.modules, "magic", types.SimpleNamespace(from_buffer=lambda *a, **k: "application/pdf"))
+    monkeypatch.setitem(sys.modules, "boto3", types.SimpleNamespace(client=lambda *a, **k: DummyClient()))
+    monkeypatch.setattr("services.ocr.textract.textract_ocr.run_in_threadpool", _run_in_threadpool)
+
+    service = AWSTextractOCRService()
+    file = types.SimpleNamespace(filename="doc.pdf", read=lambda: b"data")
+    await service.analyze(file)
+    assert dummy_uploader.deleted
+

--- a/tests/test_structured_cleaner.py
+++ b/tests/test_structured_cleaner.py
@@ -1,0 +1,29 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "app"))
+
+from services.field_correctors.structured_cleaner import StructuredFieldCorrector
+
+
+def test_structured_cleaner_groups_fields():
+    raw = {
+        "Nombre": "Juan",
+        "Teléfono de casa": "5512345678",
+        "Sueldo mensual": "$1,000",
+        "12": "[X]",
+        "Femenino": "[X]",
+        "Soltero": "[X]",
+        "Sociedad Conyugal": "[X]",
+    }
+    cleaner = StructuredFieldCorrector()
+    result = cleaner.transform(raw)
+
+    assert result["datos_personales"]["nombre"] == "Juan"
+    assert result["contacto"]["teléfono de casa"] == "5512345678"
+    assert result["finanzas"]["sueldo_mensual"] == "1000"
+    assert result["plazo_credito"] == "12"
+    assert result["genero"] == "Femenino"
+    assert result["estado_civil"] == "Soltero"
+    assert result["regimen_matrimonial"] == "Sociedad Conyugal"
+

--- a/tests/test_structured_postprocessor.py
+++ b/tests/test_structured_postprocessor.py
@@ -30,7 +30,7 @@ def test_structured_postprocessor_single_refine(monkeypatch):
     dummy_refiner = DummyRefiner()
     monkeypatch.setattr(
         "services.postprocessors.postprocessor.get_postprocessor",
-        lambda form_type: DummyPostProcessor(),
+        lambda form_type, structured=False: DummyPostProcessor(),
     )
     monkeypatch.setattr(
         "services.postprocessors.postprocessor.get_ai_refiner",


### PR DESCRIPTION
## Summary
- add structured field corrector from main branch
- expose StructuredFieldCorrector in package
- support structured output in postprocessor factory and class
- clean up temporary files uploaded to S3
- document structured output in README
- test structured cleaner and S3 deletion

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f0bcacadc83228a833f394f80b3a1