### PR TITLE
Refactor OCR pipeline configuration

### DIFF
--- a/app/services/ocr/ocr_processor.py
+++ b/app/services/ocr/ocr_processor.py
@@ -1,22 +1,41 @@
 from fastapi import UploadFile
-import os
 from models.data_response import DataResponse
 from services.ocr.factory import get_ocr_service
 from services.ocr.textract.ocrtextract import OcrTextract
+from services.postprocessors.postprocessor import StructuredPostProcessor
+from services.ai_refiners.factory import get_ai_refiner
+import logging
+
 
 class OCRProcessor:
     """Orchestrates OCR extraction and post-processing."""
 
-    def __init__(self, service_name: str | None = None, refiner_type: str | None = None):
-        self.service_name = service_name or os.getenv("OCR_SERVICE", "aws")
-        self.refiner_type = refiner_type or os.getenv("REFINER_TYPE", "gpt")
+    def __init__(self, service_name: str, refiner_type: str | None = None):
+        self.service_name = service_name
+        self.refiner_type = refiner_type
         self.service = get_ocr_service(self.service_name)
 
     async def process(self, file: UploadFile) -> DataResponse:
         if self.service_name == "aws":
-            pipeline = OcrTextract(self.service, refiner_type=self.refiner_type)
-            return await pipeline.process(file)
+            pipeline = OcrTextract()
+            result = await pipeline.process(file)
         else:
             raise NotImplementedError(
                 f"OCR service '{self.service_name}' is not supported"
             )
+
+        # always clean and structure fields
+        post = StructuredPostProcessor(result)
+        result = post.process()
+
+        # optional AI refinement of structured fields
+        if self.refiner_type:
+            try:
+                refiner = get_ai_refiner(self.refiner_type)
+                refined = refiner.refine(result.fields)
+                if isinstance(refined, dict):
+                    result.fields.update(refined)
+            except Exception as e:
+                logging.warning(f"[OCRProcessor] Error refining fields: {e}")
+
+        return result

--- a/app/services/ocr/textract/ocrtextract.py
+++ b/app/services/ocr/textract/ocrtextract.py
@@ -4,16 +4,14 @@ from services.ocr.form_identifier import FormIdentifier
 from services.ocr.textract.textract_block_parser import TextractBlockParser
 from services.ocr.textract.textract_layout_parser import TextractLayoutParser
 from services.ocr.textract.banorte_layout_parser import BanorteLayoutParser
-from services.postprocessors.postprocessor import StructuredPostProcessor
-from interfaces.ocr_service import OCRService
+from services.ocr.textract.textract_ocr import AWSTextractOCRService
 
 
 class OcrTextract:
     """Pipeline to process documents using AWS Textract."""
 
-    def __init__(self, service: OCRService, refiner_type: str = "gpt"):
-        self.service = service
-        self.refiner_type = refiner_type
+    def __init__(self):
+        self.service = AWSTextractOCRService()
 
     async def process(self, file: UploadFile) -> DataResponse:
         ocr_result = await self.service.analyze(file)
@@ -43,5 +41,4 @@ class OcrTextract:
             "fields": fields,
         }
 
-        processor = StructuredPostProcessor(data=data, refiner_type=self.refiner_type)
-        return processor.process()
+        return DataResponse(**data)

--- a/app/services/postprocessors/postprocessor.py
+++ b/app/services/postprocessors/postprocessor.py
@@ -1,48 +1,27 @@
 """Helpers to post-process OCR results into structured data."""
 
-import logging
 from models.data_response import DataResponse
 from interfaces.postprocessor import PostProcessor
 from services.postprocessors.postprocessor_factory import get_postprocessor
-from services.ai_refiners.factory import get_ai_refiner
 
 class StructuredPostProcessor(PostProcessor):
-    def __init__(self, data: DataResponse, refiner_type, structured_output: bool = False):
+    def __init__(self, data: DataResponse, structured_output: bool = False):
         self.data = data
         form_type = data.get("form_type", None)
         self.corrector = get_postprocessor(form_type, structured=structured_output)
-        self.refiner = get_ai_refiner(refiner_type)
         self.structured_output = structured_output
 
 
-    def _refine_section(self, section: str, content):
-        """Refina una sección del formulario usando IA."""
-        try:
-            refined_result = self.refiner.refine({section: content})
-            if isinstance(refined_result, dict) and section in refined_result:
-                return refined_result[section]
-            elif isinstance(refined_result, dict) and refined_result:
-                return next(iter(refined_result.values()))
-        except Exception as e:
-            logging.warning(
-                f"[PostProcessor] Error al refinar sección '{section}': {e}"
-            )
-        return content
-
     def process(self) -> DataResponse:
-        fields = self.data.get("fields")
+        if isinstance(self.data, DataResponse):
+            fields = self.data.fields
+        else:
+            fields = self.data.get("fields")
+
         structured = self.corrector.process(fields)
 
-        if self.structured_output:
-            for section, content in structured.items():
-                structured[section] = self._refine_section(section, content)
+        if isinstance(self.data, DataResponse):
+            self.data.fields = structured
         else:
-            try:
-                refined = self.refiner.refine(structured)
-                if isinstance(refined, dict):
-                    structured.update(refined)
-            except Exception as e:
-                logging.warning(f"[PostProcessor] Error al refinar campos: {e}")
-
-        self.data["fields"] = structured
+            self.data["fields"] = structured
         return self.data

--- a/tests/test_structured_postprocessor.py
+++ b/tests/test_structured_postprocessor.py
@@ -17,30 +17,13 @@ class DummyPostProcessor:
         return fields
 
 
-class DummyRefiner:
-    def __init__(self):
-        self.calls = []
-
-    def refine(self, fields):
-        self.calls.append(fields.copy())
-        return {k: v.upper() for k, v in fields.items()}
-
-
-def test_structured_postprocessor_single_refine(monkeypatch):
-    dummy_refiner = DummyRefiner()
+def test_structured_postprocessor_basic(monkeypatch):
     monkeypatch.setattr(
         "services.postprocessors.postprocessor.get_postprocessor",
         lambda form_type, structured=False: DummyPostProcessor(),
     )
-    monkeypatch.setattr(
-        "services.postprocessors.postprocessor.get_ai_refiner",
-        lambda refiner_type: dummy_refiner,
-    )
-
     data = {"fields": {"a": "x", "b": "y"}}
-    processor = StructuredPostProcessor(data, refiner_type="gpt")
+    processor = StructuredPostProcessor(data)
     result = processor.process()
 
-    assert result["fields"] == {"a": "X", "b": "Y"}
-    assert len(dummy_refiner.calls) == 1
-    assert dummy_refiner.calls[0] == {"a": "x", "b": "y"}
+    assert result["fields"] == {"a": "x", "b": "y"}


### PR DESCRIPTION
## Summary
- centralize OCR and refiner env vars in `analyze.py`
- let `OCRProcessor` apply refiners after running `StructuredPostProcessor`
- simplify `StructuredPostProcessor` to only clean and structure fields
- update tests accordingly

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684f1b8b3bc48322a4a9b141af2f330e