### PR TITLE
Fix DataResponse error in StructuredPostProcessor

### DIFF
--- a/app/interfaces/ocr_service.py
+++ b/app/interfaces/ocr_service.py
@@ -3,10 +3,11 @@
 
 from abc import ABC, abstractmethod
 from typing import Dict
+from models.raw_ocr_response import RawOCRResponse
 from fastapi import UploadFile
 
 class OCRService(ABC):
     @abstractmethod
-    async def analyze(self, file: UploadFile) -> Dict:
-        """Procesa un archivo y retorna un diccionario con los datos extraídos"""
+    async def analyze(self, file: UploadFile) -> RawOCRResponse:
+        """Procesa un archivo y retorna la salida cruda del OCR"""
         pass

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -1,0 +1,7 @@
+from .data_response import DataResponse
+from .raw_ocr_response import RawOCRResponse
+
+__all__ = [
+    "DataResponse",
+    "RawOCRResponse",
+]

--- a/app/models/raw_ocr_response.py
+++ b/app/models/raw_ocr_response.py
@@ -1,0 +1,9 @@
+from typing import Any, Dict, List
+from pydantic import BaseModel
+
+class RawOCRResponse(BaseModel):
+    """Raw output from OCR services."""
+
+    blocks: List[Dict[str, Any]]
+    s3_path: str
+    mime_type: str

--- a/app/services/ocr/textract/ocrtextract.py
+++ b/app/services/ocr/textract/ocrtextract.py
@@ -5,6 +5,7 @@ from services.ocr.textract.textract_block_parser import TextractBlockParser
 from services.ocr.textract.textract_layout_parser import TextractLayoutParser
 from services.ocr.textract.banorte_layout_parser import BanorteLayoutParser
 from services.ocr.textract.textract_ocr import AWSTextractOCRService
+from models.raw_ocr_response import RawOCRResponse
 
 
 class OcrTextract:
@@ -14,8 +15,8 @@ class OcrTextract:
         self.service = AWSTextractOCRService()
 
     async def process(self, file: UploadFile) -> DataResponse:
-        ocr_result = await self.service.analyze(file)
-        blocks = ocr_result.get("blocks", [])
+        ocr_result: RawOCRResponse = await self.service.analyze(file)
+        blocks = ocr_result.blocks
         if not blocks:
             raise RuntimeError("Textract returned no blocks")
 
@@ -37,7 +38,7 @@ class OcrTextract:
 
         data = {
             "form_type": form_type,
-            "file_name": ocr_result.get("s3_path"),
+            "file_name": ocr_result.s3_path,
             "fields": fields,
         }
 

--- a/app/services/ocr/textract/textract_ocr.py
+++ b/app/services/ocr/textract/textract_ocr.py
@@ -13,6 +13,7 @@ from fastapi.concurrency import run_in_threadpool
 from fastapi import UploadFile
 from interfaces.ocr_service import OCRService
 from services.storage.s3_uploader import S3Uploader
+from models.raw_ocr_response import RawOCRResponse
 
 class AWSTextractOCRService(OCRService):
     
@@ -22,7 +23,7 @@ class AWSTextractOCRService(OCRService):
         self.bucket = bucket_name
         self.uploader = S3Uploader(bucket_name, region_name)
 
-    async def analyze(self, file: UploadFile) -> dict:
+    async def analyze(self, file: UploadFile) -> RawOCRResponse:
         contents = await file.read()
         mime_type = magic.from_buffer(contents, mime=True)
         is_pdf = mime_type == "application/pdf"
@@ -87,8 +88,4 @@ class AWSTextractOCRService(OCRService):
 
         await run_in_threadpool(self.uploader.delete_file, s3_key)
 
-        return {
-            "blocks": blocks,
-            "s3_path": s3_key,
-            "mime_type": mime_type,
-        }
+        return RawOCRResponse(blocks=blocks, s3_path=s3_key, mime_type=mime_type)

--- a/app/services/postprocessors/postprocessor.py
+++ b/app/services/postprocessors/postprocessor.py
@@ -1,18 +1,25 @@
 """Helpers to post-process OCR results into structured data."""
 
+from typing import Any, Dict, Union
+
 from models.data_response import DataResponse
 from interfaces.postprocessor import PostProcessor
 from services.postprocessors.postprocessor_factory import get_postprocessor
 
 class StructuredPostProcessor(PostProcessor):
-    def __init__(self, data: DataResponse, structured_output: bool = False):
+    """Apply post-processing rules to OCR output."""
+
+    def __init__(self, data: Union[DataResponse, Dict[str, Any]], structured_output: bool = False):
         self.data = data
-        form_type = data.get("form_type", None)
+        if isinstance(data, DataResponse):
+            form_type = data.form_type
+        else:
+            form_type = data.get("form_type", None)
         self.corrector = get_postprocessor(form_type, structured=structured_output)
         self.structured_output = structured_output
 
 
-    def process(self) -> DataResponse:
+    def process(self) -> Union[DataResponse, Dict[str, Any]]:
         if isinstance(self.data, DataResponse):
             fields = self.data.fields
         else:


### PR DESCRIPTION
## Summary
- ensure StructuredPostProcessor handles `DataResponse` objects properly
- add RawOCRResponse model for raw OCR output
- update OCRService and Textract pipeline to use RawOCRResponse

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684f3e0d543c8322979f5f656ea584f4