### PR TITLE
Improve Banorte layout handling

### DIFF
--- a/app/services/ocr/textract/banorte_layout_parser.py
+++ b/app/services/ocr/textract/banorte_layout_parser.py
@@ -6,14 +6,27 @@ from services.ocr.textract.textract_layout_parser import TextractLayoutParser
 class BanorteLayoutParser(TextractLayoutParser):
     """Layout parser specialized for Banorte personal credit forms."""
 
-    STOP_HEADERS = {"CLAUSULAS", "CONSENTIMIENTO"}
+    STOP_HEADERS = {
+        "CLAUSULAS",
+        "CONSENTIMIENTO",
+        "CRÉDITO PERSONAL BANORTE",
+        "CREDITO PERSONAL BANORTE",
+    }
+
+    LONG_STOP_WORDS = 12
 
     def __init__(self, blocks: List[Dict]):
         super().__init__(blocks, headers=[])
         self.recognized_sections: List[str] = []
 
     def _is_stop(self, text: str) -> bool:
-        return text.strip().upper() in self.STOP_HEADERS
+        cleaned = text.strip()
+        upper = cleaned.upper()
+        if upper in self.STOP_HEADERS:
+            return True
+        if cleaned == upper and len(cleaned.split()) > self.LONG_STOP_WORDS:
+            return True
+        return False
 
     def parse(self) -> Dict[str, List[str]]:
         sections: Dict[str, List[str]] = {}

--- a/app/services/ocr/textract/ocrtextract.py
+++ b/app/services/ocr/textract/ocrtextract.py
@@ -22,19 +22,19 @@ class OcrTextract:
 
         form_type = FormIdentifier.identify_form(blocks) or "desconocido"
 
-        parser = TextractBlockParser(blocks)
+        parser = TextractBlockParser(blocks, use_line_fallback=True)
         fields = parser.extract()
-
-        layout_parser = TextractLayoutParser(blocks)
-        sections = layout_parser.parse()
-        if sections:
-            fields.update(sections)
 
         if form_type == "banorte_credito":
             banorte_parser = BanorteLayoutParser(blocks)
             extra = banorte_parser.parse()
             if extra:
                 fields.update(extra)
+        else:
+            layout_parser = TextractLayoutParser(blocks)
+            sections = layout_parser.parse()
+            if sections:
+                fields.update(sections)
 
         data = {
             "form_type": form_type,

--- a/app/services/ocr/textract/textract_block_parser.py
+++ b/app/services/ocr/textract/textract_block_parser.py
@@ -50,7 +50,7 @@ class TextractBlockParser:
             else:
                 self.field_dict[key_norm] = "VALUE_NOT_FOUND"
 
-        if not self.field_dict and self.use_line_fallback:
+        if self.use_line_fallback:
             self._extract_from_lines()
 
         return self.field_dict
@@ -83,4 +83,7 @@ class TextractBlockParser:
             if not key or not val:
                 continue
             key_norm = normalize_key(key) if self.normalize_keys else key
+            existing = self.field_dict.get(key_norm)
+            if existing and existing != "VALUE_NOT_FOUND":
+                continue
             self.field_dict[key_norm] = val

--- a/app/services/postprocessors/form_postprocessor/banorte_credito.py
+++ b/app/services/postprocessors/form_postprocessor/banorte_credito.py
@@ -45,6 +45,13 @@ class BanorteCreditoPostProcessor(GenericPostProcessor):
         "puesto_en_la_empresa": ["puesto"],
     }
 
+    def _looks_like_key(self, text: str) -> bool:
+        text = text.strip().lower()
+        for patterns in self.FIELD_PATTERNS.values():
+            if any(p in text for p in patterns):
+                return True
+        return False
+
     def _extract_from_sections(self, raw_fields: dict) -> dict:
         extracted: dict = {}
         for section in self.SECTION_KEYS:
@@ -52,15 +59,28 @@ class BanorteCreditoPostProcessor(GenericPostProcessor):
             if not isinstance(lines, list):
                 continue
             i = 0
-            while i < len(lines) - 1:
+            while i < len(lines):
                 key = lines[i].strip().lower()
-                val = lines[i + 1].strip()
+                matched_field = None
                 for field, patterns in self.FIELD_PATTERNS.items():
-                    if any(p in key for p in patterns) and val:
-                        extracted[field] = val
-                        i += 1
+                    if any(p in key for p in patterns):
+                        matched_field = field
                         break
-                i += 1
+                if matched_field:
+                    j = i + 1
+                    while j < len(lines):
+                        candidate = lines[j].strip()
+                        if candidate and not self._looks_like_key(candidate):
+                            if matched_field == "email" and "@" not in candidate:
+                                j += 1
+                                continue
+                            if matched_field not in extracted:
+                                extracted[matched_field] = candidate
+                            break
+                        j += 1
+                    i = j
+                else:
+                    i += 1
         return extracted
     def process(self, raw_fields: dict, layout: dict | None = None) -> dict:
         """Clean generic fields and integrate checklist values.
@@ -74,7 +94,8 @@ class BanorteCreditoPostProcessor(GenericPostProcessor):
         """
 
         extracted = self._extract_from_sections(raw_fields)
-        raw_fields.update(extracted)
+        for key, value in extracted.items():
+            raw_fields.setdefault(key, value)
         cleaned = super().process(raw_fields)
         checklist = cleaned.pop("checklist", [])
         if isinstance(checklist, list):

--- a/tests/test_extractor.py
+++ b/tests/test_extractor.py
@@ -81,3 +81,14 @@ def test_kv_map_deduplicates_values():
     fields = extractor.extract()
     assert fields["folio"] == "123"
 
+
+def test_line_fallback_supplements_missing_values():
+    blocks = [
+        {"Id": "kw", "BlockType": "WORD", "Text": "E-mail"},
+        {"Id": "k1", "BlockType": "KEY_VALUE_SET", "EntityTypes": ["KEY"], "Relationships": [{"Type": "CHILD", "Ids": ["kw"]}]},
+        {"Id": "l1", "BlockType": "LINE", "Text": "E-mail: user@example.com"},
+    ]
+    extractor = TextractBlockParser(blocks, use_line_fallback=True)
+    fields = extractor.extract()
+    assert fields["email"] == "user@example.com"
+

--- a/tests/test_layout_parser.py
+++ b/tests/test_layout_parser.py
@@ -45,3 +45,30 @@ def test_banorte_layout_parser_sections():
     assert sections["domicilio"] == ["Av Siempre Viva", "Col Centro"]
     assert sections["empleo"] == ["Empresa XYZ", "Puesto ABC"]
     assert sections["referencias_personales"] == ["Carlos Diaz", "555-1234"]
+
+
+def test_banorte_layout_parser_stops_long_lines():
+    long_text = (
+        "OPERATIVA DE HISTORIAL O INFORMACION CREDITICIA Y DE CUALQUIER OTRA "
+        "NATURALEZA QUE LE SEA PROPORCIONADA POR MI O POR TERCEROS CON MI "
+        "AUTORIZACION A CUALQUIERA DE LAS ENTIDADES FINANCIERAS DE BANCO "
+        "MERCANTIL DEL"
+    )
+    blocks = [
+        {"Id": "1", "BlockType": "LINE", "Text": "INFORMACION PERSONAL", "Page": 1,
+         "Geometry": {"BoundingBox": {"Top": 0.1, "Left": 0}}},
+        {"Id": "2", "BlockType": "LINE", "Text": "Nombre", "Page": 1,
+         "Geometry": {"BoundingBox": {"Top": 0.15, "Left": 0}}},
+        {"Id": "3", "BlockType": "LINE", "Text": "Juan", "Page": 1,
+         "Geometry": {"BoundingBox": {"Top": 0.2, "Left": 0}}},
+        {"Id": "4", "BlockType": "LINE", "Text": long_text, "Page": 1,
+         "Geometry": {"BoundingBox": {"Top": 0.3, "Left": 0}}},
+        {"Id": "5", "BlockType": "LINE", "Text": "DOMICILIO", "Page": 1,
+         "Geometry": {"BoundingBox": {"Top": 0.4, "Left": 0}}},
+        {"Id": "6", "BlockType": "LINE", "Text": "Calle 5", "Page": 1,
+         "Geometry": {"BoundingBox": {"Top": 0.45, "Left": 0}}},
+    ]
+    parser = BanorteLayoutParser(blocks)
+    sections = parser.parse()
+    assert sections["informacion_personal"] == ["Nombre", "Juan"]
+    assert sections["domicilio"] == ["Calle 5"]

--- a/tests/test_postprocessor.py
+++ b/tests/test_postprocessor.py
@@ -52,3 +52,33 @@ def test_banorte_postprocessor_checklist():
     assert result["tipo_de_empleo"] == "asalariado"
     assert result["politicamente_expuesto"] == "no"
 
+
+def test_banorte_postprocessor_extract_email():
+    processor = BanorteCreditoPostProcessor()
+    raw = {
+        "informacion_personal": [
+            "Teléfono Celular",
+            "4432222222",
+            "E-mail",
+            "4431111111",
+            "usuario@example.com",
+            "Tipo de Identificación",
+            "INE",
+        ]
+    }
+    result = processor.process(raw)
+    assert result["email"] == "usuario@example.com"
+
+
+def test_banorte_postprocessor_preserves_existing_field():
+    processor = BanorteCreditoPostProcessor()
+    raw = {
+        "email": "orig@example.com",
+        "informacion_personal": [
+            "E-mail",
+            "otro@example.com",
+        ],
+    }
+    result = processor.process(raw)
+    assert result["email"] == "orig@example.com"
+


### PR DESCRIPTION
## Summary
- skip generic layout parsing on Banorte forms
- stop parsing when long uppercase lines appear in Banorte layouts
- keep existing fields when merging parsed sections
- handle keys without values in Banorte postprocessor
- enable line fallback parsing in TextractBlockParser and OCR pipeline
- add regression tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684f47c1661c8322a87ac9953caed1a5