### PR TITLE
Fix layout fields removal

### DIFF
--- a/app/services/postprocessors/form_postprocessor/banorte_credito.py
+++ b/app/services/postprocessors/form_postprocessor/banorte_credito.py
@@ -96,6 +96,10 @@ class BanorteCreditoPostProcessor(GenericPostProcessor):
         extracted = self._extract_from_sections(raw_fields)
         for key, value in extracted.items():
             raw_fields.setdefault(key, value)
+
+        for section in self.SECTION_KEYS:
+            raw_fields.pop(section, None)
+
         cleaned = super().process(raw_fields)
         checklist = cleaned.pop("checklist", [])
         if isinstance(checklist, list):

--- a/tests/test_postprocessor.py
+++ b/tests/test_postprocessor.py
@@ -82,3 +82,17 @@ def test_banorte_postprocessor_preserves_existing_field():
     result = processor.process(raw)
     assert result["email"] == "orig@example.com"
 
+
+def test_banorte_postprocessor_drops_section_keys():
+    processor = BanorteCreditoPostProcessor()
+    raw = {
+        "informacion_personal": ["Nombre", "Juan"],
+        "domicilio": ["Calle Falsa 123"],
+        "empleo": ["Empresa XYZ"],
+    }
+    result = processor.process(raw)
+    assert "informacion_personal" not in result
+    assert "domicilio" not in result
+    assert "empleo" not in result
+    assert result["nombre"] == "Juan"
+


### PR DESCRIPTION
## Summary
- clean up `BanorteCreditoPostProcessor` output to drop section keys after parsing
- verify section keys are removed in postprocessor tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f4fddc5648322b1c79c2abfd0efa1