### PR TITLE
Refine OCR service responsibility

### DIFF
--- a/app/interfaces/ocr_service.py
+++ b/app/interfaces/ocr_service.py
@@ -1,11 +1,11 @@
 # app/interfaces/ocr_service.py
 from abc import ABC, abstractmethod
-from typing import Dict
 from fastapi import UploadFile
+from models import OCRResponse
 
 
 class OCRService(ABC):
     @abstractmethod
-    async def analyze(self, file: UploadFile) -> Dict:
-        """Procesa un archivo y retorna un diccionario con los datos extraídos"""
+    async def analyze(self, file: UploadFile) -> OCRResponse:
+        """Procesa un archivo y retorna los datos extraídos"""
         pass

--- a/app/models/ocr_response.py
+++ b/app/models/ocr_response.py
@@ -4,4 +4,5 @@ from typing import Dict, Union
 
 
 class OCRResponse(BaseModel):
+    form_name: str
     fields: Dict[str, Union[str, Dict[str, str]]]

--- a/app/services/ocr/form_identifier.py
+++ b/app/services/ocr/form_identifier.py
@@ -1,14 +1,52 @@
-class FormIdentifier:
-    """Simple form detection based on keyword presence."""
+from typing import List, Dict
+import unicodedata
 
+
+class FormIdentifier:
+    """Identify a form based on OCR output."""
+
+    # Map internal form types to the keywords that should be present in the
+    # textual form name returned by the OCR service.
     RULES = {
-        "credit_application": ["curp", "rfc", "sueldo"],
+        "banorte_credito": ["banorte", "credito", "personal"],
     }
 
+    DEFAULT_TYPE = "unknown"
+
     @classmethod
-    def identify(cls, fields: dict) -> str:
-        field_text = " ".join(k.lower() for k in fields.keys())
+    def identify(cls, form_name: str = "", fields: Dict | None = None) -> str:
+        """Return a canonical form type from a raw form name or fields."""
+        if form_name:
+            normalized = ''.join(
+                c for c in unicodedata.normalize('NFKD', form_name.lower())
+                if not unicodedata.combining(c)
+            )
+        else:
+            normalized = ""
+        name = normalized
         for form, keywords in cls.RULES.items():
-            if any(k in field_text for k in keywords):
+            if all(k in name for k in keywords):
                 return form
-        return "unknown"
+
+        # Fallback: try to infer from the field names if no form name provided.
+        if fields:
+            field_text = " ".join(k.lower() for k in fields.keys())
+            for form, keywords in cls.RULES.items():
+                if all(k in field_text for k in keywords):
+                    return form
+
+        return cls.DEFAULT_TYPE
+
+    @classmethod
+    def identify_from_blocks(cls, blocks: List[Dict]) -> str:
+        """Identify form type directly from Textract blocks."""
+        raw_name = cls.extract_name_from_blocks(blocks)
+        return cls.identify(raw_name)
+
+    @staticmethod
+    def extract_name_from_blocks(blocks: List[Dict]) -> str:
+        """Return the first line of the first page as the form name."""
+        for block in blocks:
+            if block.get("BlockType") == "LINE" and block.get("Page", 1) == 1:
+                return block.get("Text", "").strip()
+        return ""

--- a/app/services/ocr_processor.py
+++ b/app/services/ocr_processor.py
@@ -3,7 +3,6 @@ from fastapi import UploadFile
 from services.factory import get_ocr_service
 from services.postprocessors.postprocessor_factory import get_postprocessor
 from services.ai_refiners.factory import get_ai_refiner
-from services.ocr.form_identifier import FormIdentifier
 from services.utils.logger import get_logger
 
 
@@ -18,11 +17,11 @@ class OCRProcessor:
     async def analyze(self, file: UploadFile) -> Dict:
         self.logger.info("Starting analysis for %s", file.filename)
         raw = await self.ocr_service.analyze(file)
-        form_type = FormIdentifier.identify(raw["fields"])
+        form_type = raw.form_name
 
         self.logger.info("Identified form type: %s", form_type)
         postprocessor = get_postprocessor(form_type=form_type)
-        processed = postprocessor.process(raw["fields"])
+        processed = postprocessor.process(raw.fields)
 
         refined = {}
         if self.refiner_type:
@@ -51,3 +50,4 @@ class OCRProcessor:
             except Exception:
                 # if refinement fails keep original
                 fields[section] = content
+

--- a/tests/test_form_identifier.py
+++ b/tests/test_form_identifier.py
@@ -1,0 +1,18 @@
+import json
+from services.ocr.form_identifier import FormIdentifier
+
+
+def test_extract_and_identify_form():
+    with open('app/examples/analyzeDocResponse.json', encoding='utf-8') as f:
+        data = json.load(f)
+    form_name = FormIdentifier.extract_name_from_blocks(data['Blocks'])
+    assert 'CRÉDITO PERSONAL BANORTE' in form_name
+    form_type = FormIdentifier.identify(form_name)
+    assert form_type == 'banorte_credito'
+
+    form_type_blocks = FormIdentifier.identify_from_blocks(data['Blocks'])
+    assert form_type_blocks == 'banorte_credito'
+
+
+def test_identify_unknown():
+    assert FormIdentifier.identify('some random text') == 'unknown'


### PR DESCRIPTION
## Summary
- keep canonical form name extraction inside OCR service
- expose `identify_from_blocks` helper in `FormIdentifier`
- update `OCRProcessor` to rely on OCR service output
- extend tests for new helper

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6850723814dc8322a857efa6849ed014