### PR TITLE
Move AI refinement to dedicated service

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 # OCR configuration
 OCR_SERVICE=aws
-REFINER_TYPE=
+AI_MODELS_URL=http://ai_models:8080
 
 # AWS
 AWS_ACCESS_KEY_ID=your-access-key

--- a/README.md
+++ b/README.md
@@ -5,6 +5,12 @@ processed using an OCR backend (AWS Textract by default) and the extracted
 fields are optionally refined using AI models. A set of cleaners normalises the
 data to return a structured JSON response.
 
+The provided `ai_models` service hosts all AI models. It performs a first pass
+with a lightweight mT5 model
+(`dreuxx26/Multilingual-grammar-Corrector-using-mT5-small`) to fix common
+errors and then sends the text to ChatGPT for a final correction. The API
+container simply calls this service to refine OCR results.
+
 ## Installation
 
 1. Clone this repository.
@@ -23,14 +29,14 @@ The API will be available at `http://localhost:8000` and the web interface at
 | Variable | Description |
 | -------- | ----------- |
 | `OCR_SERVICE` | Name of the OCR backend (`aws` by default). |
-| `REFINER_TYPE` | Optional AI refiner (`gpt` or `huggingface`). |
+| `AI_MODELS_URL` | Base URL for the `ai_models` service. |
 | `AWS_ACCESS_KEY_ID` | AWS credential for Textract/S3. |
 | `AWS_SECRET_ACCESS_KEY` | AWS credential for Textract/S3. |
 | `AWS_REGION` | AWS region used by Textract. |
 | `AWS_BUCKET` | S3 bucket for temporary uploads. |
-| `OPENAI_API_KEY` | API key for GPT refiner (if used). |
-| `OPENAI_MODEL` | Model name for GPT refiner. |
-| `HF_MODEL_NAME` | Model name for HuggingFace refiner. |
+| `OPENAI_API_KEY` | API key used by the `ai_models` service. |
+| `OPENAI_MODEL` | ChatGPT model name. |
+| `HF_MODEL_NAME` | Name of the local grammar model. |
 
 ## Usage
 

--- a/ai_models/app/logger.py
+++ b/ai_models/app/logger.py
@@ -1,0 +1,10 @@
+import logging
+import sys
+
+def get_logger(name: str) -> logging.Logger:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="[%(asctime)s] %(levelname)s - %(name)s: %(message)s",
+        stream=sys.stdout,
+    )
+    return logging.getLogger(name)

--- a/ai_models/app/main.py
+++ b/ai_models/app/main.py
@@ -1,15 +1,27 @@
-# ai_models/app/main.py
-from fastapi import FastAPI, Request
+from fastapi import FastAPI
 from pydantic import BaseModel
+from typing import Dict
+
 from app.model_service import GrammarCorrector
+from app.refiner_service import CombinedRefiner
 
 app = FastAPI()
-model = GrammarCorrector()
+corrector = GrammarCorrector()
+refiner = CombinedRefiner()
 
 class TextIn(BaseModel):
     text: str
 
+class FieldsIn(BaseModel):
+    fields: Dict[str, str]
+
 @app.post("/correct")
 def correct_text(data: TextIn):
-    result = model.correct(data.text)
+    result = corrector.correct(data.text)
     return {"corrected": result}
+
+@app.post("/refine")
+def refine_fields(data: FieldsIn):
+    refined = refiner.refine(data.fields)
+    return {"fields": refined}
+

--- a/ai_models/app/refiner_service.py
+++ b/ai_models/app/refiner_service.py
@@ -1,0 +1,65 @@
+import os
+import json
+from typing import Dict
+import openai
+
+from .model_service import GrammarCorrector
+from .logger import get_logger
+
+
+class ChatGPTRefiner:
+    """Wrapper around OpenAI ChatGPT for refining text fields."""
+
+    def __init__(self):
+        self.logger = get_logger(self.__class__.__name__)
+        self.model = os.getenv("OPENAI_MODEL", "gpt-3.5-turbo")
+        api_key = os.getenv("OPENAI_API_KEY")
+        if api_key:
+            openai.api_key = api_key
+
+    def refine(self, fields: Dict[str, str]) -> Dict[str, str]:
+        json_input = json.dumps(fields, ensure_ascii=False, indent=2)
+        system_msg = (
+            "Eres un asistente que corrige ortograf\u00eda y gram\u00e1tica en JSON. "
+            "Devuelve \u00fanicamente el JSON corregido."
+        )
+        messages = [
+            {"role": "system", "content": system_msg},
+            {
+                "role": "user",
+                "content": f"Corrige este JSON manteniendo su estructura:\n{json_input}",
+            },
+        ]
+        try:
+            response = openai.chat.completions.create(
+                model=self.model,
+                messages=messages,
+                temperature=0.2,
+                max_tokens=1000,
+                response_format={"type": "json_object"},
+            )
+            text = response.choices[0].message.content.strip()
+            return json.loads(text)
+        except Exception as exc:
+            self.logger.warning("GPT refinement failed: %s", exc)
+            return fields
+
+
+class CombinedRefiner:
+    """Apply local grammar correction before delegating to ChatGPT."""
+
+    def __init__(self, use_local_corrector: bool = True):
+        self.logger = get_logger(self.__class__.__name__)
+        self.use_local = use_local_corrector
+        self.corrector = GrammarCorrector() if use_local_corrector else None
+        self.gpt = ChatGPTRefiner()
+
+    def refine(self, fields: Dict[str, str]) -> Dict[str, str]:
+        current = fields
+        if self.corrector:
+            try:
+                current = {k: self.corrector.correct(v) for k, v in fields.items()}
+            except Exception as exc:
+                self.logger.warning("Local correction failed: %s", exc)
+                current = fields
+        return self.gpt.refine(current)

--- a/ai_models/requirements.txt
+++ b/ai_models/requirements.txt
@@ -4,8 +4,7 @@ transformers
 torch
 pydantic
 huggingface_hub
-transformers
-torch
 protobuf>=3.20
 sentencepiece
 python-dotenv
+openai

--- a/app/api/routes/analyze.py
+++ b/app/api/routes/analyze.py
@@ -4,10 +4,9 @@ from models.data_response import DataResponse
 from services.ocr_processor import OCRProcessor
 
 SERVICE_NAME = os.getenv("OCR_SERVICE", "aws")
-REFINER_TYPE = os.getenv("REFINER_TYPE")
 
 router = APIRouter()
-processor = OCRProcessor(SERVICE_NAME, REFINER_TYPE)
+processor = OCRProcessor(SERVICE_NAME)
 
 
 @router.post("/analyze", response_model=DataResponse)

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -6,9 +6,6 @@ requests
 pydantic
 python-multipart
 python-magic
-transformers
-torch
 protobuf>=3.20
 sentencepiece
-openai
 python-dotenv

--- a/app/services/ai_refiners/factory.py
+++ b/app/services/ai_refiners/factory.py
@@ -1,22 +1,12 @@
 # app/services/ai_refiners/factory.py
 from interfaces.ai_refiner import AIRefiner
 import os
+from services.ai_refiners.remote_refiner import RemoteRefiner
 
 
-def get_ai_refiner(refiner_type: str | None) -> AIRefiner | None:
-    if not refiner_type:
-        return None
-    refiner_type = refiner_type.lower()
-
-    if refiner_type == "gpt":
-        from services.ai_refiners.gpt_refiner import GPTRefiner
-        api_key = os.getenv("OPENAI_API_KEY")
-        model = os.getenv("OPENAI_MODEL", "gpt-3.5-turbo")
-        return GPTRefiner(api_key=api_key, model=model)
-
-    if refiner_type == "huggingface":
-        from services.ai_refiners.huggingface_refiner import HuggingFaceRefiner
-        model_name = os.getenv("HF_MODEL_NAME", "dreuxx26/Multilingual-grammar-Corrector-using-mT5-small")
-        return HuggingFaceRefiner(model_name=model_name)
+def get_ai_refiner(_: str | None = None) -> AIRefiner:
+    """Return the remote refiner pointing to the ai_models service."""
+    base_url = os.getenv("AI_MODELS_URL", "http://ai_models:8080")
+    return RemoteRefiner(base_url=base_url)
 
 

--- a/app/services/ai_refiners/remote_refiner.py
+++ b/app/services/ai_refiners/remote_refiner.py
@@ -1,0 +1,23 @@
+from typing import Dict
+import requests
+
+from interfaces.ai_refiner import AIRefiner
+from services.utils.logger import get_logger
+
+
+class RemoteRefiner(AIRefiner):
+    """Refiner that delegates processing to an external API."""
+
+    def __init__(self, base_url: str):
+        self.base_url = base_url.rstrip("/")
+        self.logger = get_logger(self.__class__.__name__)
+
+    def refine(self, fields: Dict[str, str]) -> Dict[str, str]:
+        try:
+            resp = requests.post(f"{self.base_url}/refine", json={"fields": fields}, timeout=30)
+            resp.raise_for_status()
+            data = resp.json()
+            return data.get("fields", fields)
+        except Exception as exc:
+            self.logger.warning("Remote refinement failed: %s", exc)
+            return fields

--- a/app/services/ocr_processor.py
+++ b/app/services/ocr_processor.py
@@ -9,10 +9,9 @@ from services.utils.logger import get_logger
 class OCRProcessor:
     """Coordinates OCR extraction and postprocessing."""
 
-    def __init__(self, service_name: str = "aws", refiner_type: str | None = None):
+    def __init__(self, service_name: str = "aws"):
         self.logger = get_logger(self.__class__.__name__)
         self.ocr_service = get_ocr_service(service_name)
-        self.refiner_type = refiner_type
 
     async def analyze(self, file: UploadFile) -> Dict:
         self.logger.info("Starting analysis for %s", file.filename)
@@ -24,30 +23,12 @@ class OCRProcessor:
         processed = postprocessor.process(raw.fields)
 
         refined = {}
-        if self.refiner_type:
-            try:
-                refiner_service = get_ai_refiner(self.refiner_type)
-                refined = refiner_service.refine(fields=processed)
-            except Exception as exc:
-                self.logger.warning("Refinement failed: %s", exc)
+        try:
+            refiner_service = get_ai_refiner(None)
+            refined = refiner_service.refine(fields=processed)
+        except Exception as exc:
+            self.logger.warning("Refinement failed: %s", exc)
 
         return {"form_type": form_type, "fields": refined | processed}
 
-    def refiner(self, fields: Dict,refiner_type: str | None = None):
-        """Get the AI refiner for the specified type."""
-        if not self.refiner_type:
-            return fields
-
-        for section, content in fields.items():
-            try:
-                result = self.refiner.refine({section: content})
-                if isinstance(content, dict):
-                    if isinstance(result, dict) and result:
-                        fields[section] = next(iter(result.values()))
-                else:
-                    if isinstance(result, dict) and section in result:
-                        fields[section] = result[section]
-            except Exception:
-                # if refinement fails keep original
-                fields[section] = content
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,18 +29,21 @@ services:
       - api
     restart: unless-stopped
 
-  # ai_models:
-  #     build:
-  #       context: ./ai_models
-  #       dockerfile: Dockerfile.ai_models
-  #     container_name: ocr_ai_models
-  #     ports:
-  #       - "8080:8080"
-  #     volumes:
-  #       - ./ai_models:/app
-  #       - ./models:/app/models  # Aquí colocarás tu modelo Hugging Face descargado
-  #     environment:
-  #       - TRANSFORMERS_CACHE=/app/models
+  ai_models:
+    build:
+      context: ./ai_models
+      dockerfile: Dockerfile.ai_models
+    container_name: ocr_ai_models
+    ports:
+      - "8080:8080"
+    volumes:
+      - ./ai_models:/app
+      - ./models:/app/models  # Aquí colocarás tu modelo Hugging Face descargado
+    environment:
+      - TRANSFORMERS_CACHE=/app/models
+      - OPENAI_API_KEY=${OPENAI_API_KEY}
+      - OPENAI_MODEL=${OPENAI_MODEL}
+      - HF_MODEL_NAME=${HF_MODEL_NAME}
 
   db:
     image: postgres:15


### PR DESCRIPTION
## Summary
- shift ChatGPT-based refiner to `ai_models` service
- add pre-correction step with a lightweight mT5 model
- remove AI models from API container and always call remote service
- pass OpenAI credentials to `ai_models` container
- streamline environment variables and documentation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6850a562215883229a9a242948099924