### PR TITLE
Improve textract parsing and add generic cleaner

### DIFF
--- a/app/services/field_correctors/banorte_credito_cleaner.py
+++ b/app/services/field_correctors/banorte_credito_cleaner.py
@@ -3,7 +3,7 @@
 import re
 from typing import Optional, Dict
 from interfaces.field_corrector import FieldCorrector
-from services.field_correctors.basic_cleaner import BasicFieldCorrector
+from services.field_correctors.basic_field_corrector import BasicFieldCorrector
 
 
 class BanorteCreditoFieldCorrector(FieldCorrector):

--- a/app/services/field_correctors/basic_field_corrector.py
+++ b/app/services/field_correctors/basic_field_corrector.py
@@ -1,4 +1,4 @@
-# app/services/field_correctors/basic_cleaner.py
+# app/services/field_correctors/basic_field_corrector.py
 
 import re
 from typing import Optional
@@ -6,10 +6,36 @@ from interfaces.field_corrector import FieldCorrector
 
 
 class BasicFieldCorrector(FieldCorrector):
+    """Perform simple, field-level corrections."""
+
+    @staticmethod
+    def _fix_common_ocr_errors(text: str) -> str:
+        """Correct common OCR mistakes like 'O' vs '0' or 'l' vs '1'."""
+        if any(c.isdigit() for c in text):
+            corrected = []
+            for i, ch in enumerate(text):
+                if ch in {"O", "o"}:
+                    if (i > 0 and text[i - 1].isdigit()) or (
+                        i + 1 < len(text) and text[i + 1].isdigit()
+                    ):
+                        corrected.append("0")
+                        continue
+                if ch in {"I", "l"}:
+                    if (i > 0 and text[i - 1].isdigit()) or (
+                        i + 1 < len(text) and text[i + 1].isdigit()
+                    ):
+                        corrected.append("1")
+                        continue
+                corrected.append(ch)
+            return "".join(corrected)
+        return text
+
     def correct(self, key: str, value: str) -> Optional[str]:
         value = value.strip()
         if not value:
             return None
+
+        value = self._fix_common_ocr_errors(value)
 
         key_lower = key.lower()
 
@@ -20,7 +46,7 @@ class BasicFieldCorrector(FieldCorrector):
         elif "nombre" in key_lower or "apellido" in key_lower:
             value = re.sub(r"[^\w\sñÑáéíóúÁÉÍÓÚ]", "", value)
             value = " ".join(part.capitalize() for part in value.split())
-        elif "teléfono" in key_lower or "celular" in key_lower:
+        elif any(t in key_lower for t in ["teléfono", "telefono", "celular"]):
             value = re.sub(r"[^\d]", "", value)
             if len(value) < 10:
                 return None

--- a/app/services/field_correctors/generic_field_cleaner.py
+++ b/app/services/field_correctors/generic_field_cleaner.py
@@ -1,0 +1,34 @@
+from typing import Dict
+import re
+from services.field_correctors.basic_field_corrector import BasicFieldCorrector
+from services.utils.logger import get_logger
+
+class GenericFieldCleaner:
+    """Clean a flat dict of fields without altering keys."""
+
+    def __init__(self):
+        self.corrector = BasicFieldCorrector()
+        self.logger = get_logger(self.__class__.__name__)
+
+    @staticmethod
+    def _pre_clean(value: str) -> str:
+        value = re.sub(r"\s+", " ", value).strip()
+        return value
+
+    @staticmethod
+    def _fix_ocr_errors(value: str) -> str:
+        if any(c.isdigit() for c in value):
+            value = re.sub(r"(?<=\d)[Oo](?=\d)|[Oo](?=\d)|(?<=\d)[Oo]", "0", value)
+            value = re.sub(r"(?<=\d)[Il](?=\d)|[Il](?=\d)|(?<=\d)[Il]", "1", value)
+        return value
+
+    def clean(self, fields: Dict[str, str]) -> Dict[str, str]:
+        cleaned: Dict[str, str] = {}
+        for key, value in fields.items():
+            self.logger.info("Cleaning %s: %s", key, value)
+            val = self._pre_clean(str(value))
+            val = self._fix_ocr_errors(val)
+            corrected = self.corrector.correct(key, val)
+            cleaned[key] = corrected if corrected is not None else val
+            self.logger.info("Result %s: %s", key, cleaned[key])
+        return cleaned

--- a/app/services/ocr/textract/textract_block_parser.py
+++ b/app/services/ocr/textract/textract_block_parser.py
@@ -1,7 +1,12 @@
-from typing import Dict, List
+from typing import Dict, List, Tuple
+import re
+from services.utils.logger import get_logger
 
 
 class TextractBlockParser:
+    def __init__(self):
+        self.logger = get_logger(self.__class__.__name__)
+
     @staticmethod
     def _get_text(block: dict, block_map: dict) -> str:
         text = ""
@@ -15,7 +20,21 @@ class TextractBlockParser:
                         text += "[X] "
         return text.strip()
 
+    def _extract_from_line(self, text: str) -> Tuple[str, str] | None:
+        if ':' in text:
+            key, value = text.split(':', 1)
+            key, value = key.strip(), value.strip()
+            if key and value:
+                return key, value
+        match = re.match(r"(.{3,50}?)[ \t]{2,}(.*)", text)
+        if match:
+            key, value = match.group(1).strip(), match.group(2).strip()
+            if key and value:
+                return key, value
+        return None
+
     def parse(self, blocks: List[dict]) -> Dict[str, str]:
+        self.logger.info("Parsing %s blocks", len(blocks))
         key_map = {}
         value_map = {}
         block_map = {}
@@ -41,4 +60,19 @@ class TextractBlockParser:
                             value_text = self._get_text(value_block, block_map)
             if key_text:
                 field_dict[key_text] = value_text
+
+        self.logger.info("Key-value pairs extracted: %s", len(field_dict))
+
+        added = 0
+        for block in blocks:
+            if block.get("BlockType") == "LINE":
+                text = block.get("Text", "").strip()
+                kv = self._extract_from_line(text)
+                if kv:
+                    k, v = kv
+                    if k not in field_dict or not field_dict[k]:
+                        field_dict[k] = v
+                        added += 1
+
+        self.logger.info("Additional pairs from lines: %s", added)
         return field_dict

--- a/app/services/postprocessors/basic_postprocessor.py
+++ b/app/services/postprocessors/basic_postprocessor.py
@@ -1,6 +1,6 @@
 from typing import Dict
 from interfaces.postprocessor import PostProcessor
-from services.field_correctors.basic_cleaner import BasicFieldCorrector
+from services.field_correctors.basic_field_corrector import BasicFieldCorrector
 from services.utils.normalization import normalize_key
 
 

--- a/tests/test_basic_field_corrector.py
+++ b/tests/test_basic_field_corrector.py
@@ -1,5 +1,5 @@
 import pytest
-from services.field_correctors.basic_cleaner import BasicFieldCorrector
+from services.field_correctors.basic_field_corrector import BasicFieldCorrector
 
 bc = BasicFieldCorrector()
 
@@ -14,5 +14,5 @@ bc = BasicFieldCorrector()
     ('r.f.c.', ' abcd-010101-xx1 ', 'ABCD010101XX1'),
     ('c.p.', ' 12,345 ', '12345'),
 ])
-def test_basic_cleaner(key, value, expected):
+def test_basic_field_corrector(key, value, expected):
     assert bc.correct(key, value) == expected

--- a/tests/test_generic_field_cleaner.py
+++ b/tests/test_generic_field_cleaner.py
@@ -1,0 +1,18 @@
+from services.field_correctors.generic_field_cleaner import GenericFieldCleaner
+
+
+def test_generic_cleaner():
+    cleaner = GenericFieldCleaner()
+    data = {
+        'email': ' TEST@EXAMPLE.COM ',
+        'monto': '1O0',
+        'telefono': '55 123-45678',
+        'nombre': ' juan ',
+        'otro': ' valor '
+    }
+    result = cleaner.clean(data)
+    assert result['email'] == 'test@example.com'
+    assert result['monto'] == '100'
+    assert result['telefono'] == '5512345678'
+    assert result['nombre'] == 'Juan'
+    assert result['otro'] == 'valor'

--- a/tests/test_textract_parser.py
+++ b/tests/test_textract_parser.py
@@ -1,0 +1,27 @@
+from services.ocr.textract.textract_block_parser import TextractBlockParser
+
+
+def test_parser_combines_lines():
+    blocks = [
+        {
+            'Id': '1',
+            'BlockType': 'KEY_VALUE_SET',
+            'EntityTypes': ['KEY'],
+            'Relationships': [{'Type': 'CHILD', 'Ids': ['1w']}, {'Type': 'VALUE', 'Ids': ['2']}]
+        },
+        {'Id': '1w', 'BlockType': 'WORD', 'Text': 'Nombre'},
+        {
+            'Id': '2',
+            'BlockType': 'KEY_VALUE_SET',
+            'EntityTypes': ['VALUE'],
+            'Relationships': [{'Type': 'CHILD', 'Ids': ['2w']}]
+        },
+        {'Id': '2w', 'BlockType': 'WORD', 'Text': 'Juan'},
+        {'Id': '3', 'BlockType': 'LINE', 'Text': 'Apellido: Perez'},
+        {'Id': '4', 'BlockType': 'LINE', 'Text': 'Telefono    1234567890'}
+    ]
+    parser = TextractBlockParser()
+    result = parser.parse(blocks)
+    assert result['Nombre'] == 'Juan'
+    assert result['Apellido'] == 'Perez'
+    assert result['Telefono'] == '1234567890'


### PR DESCRIPTION
## Summary
- move basic field logic to new `basic_field_corrector.py`
- add generic cleaner for flat dictionaries
- enhance OCR Textract block parser to also parse line heuristics
- update imports and tests accordingly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850bf2c9f388322b13bc64a0d870d86