### PR TITLE
Enhance validations and restructure credit form

### DIFF
--- a/app/services/field_correctors/banorte_credito_cleaner.py
+++ b/app/services/field_correctors/banorte_credito_cleaner.py
@@ -1,6 +1,7 @@
 # app/services/field_correctors/structured_cleaner.py
 
 import re
+import unicodedata
 from typing import Optional, Dict
 from interfaces.field_corrector import FieldCorrector
 from services.field_correctors.basic_field_corrector import BasicFieldCorrector
@@ -11,7 +12,11 @@ class BanorteCreditoFieldCorrector(FieldCorrector):
         self.basic = BasicFieldCorrector()
 
     def _clean_key(self, key: str) -> str:
-        return re.sub(r"[:\-\.]", "", key).strip().lower()
+        key = re.sub(r"[:\-\.]", "", key).strip().lower()
+        key = "".join(
+            c for c in unicodedata.normalize("NFKD", key) if not unicodedata.combining(c)
+        )
+        return key
 
     def _is_selected(self, value: str) -> bool:
         return "[x]" in value.lower()
@@ -21,30 +26,36 @@ class BanorteCreditoFieldCorrector(FieldCorrector):
 
     def _init_structured(self) -> Dict:
         return {
-            "datos_personales": {},
+            "datos_personales": {
+                "genero": None,
+                "estado_civil": None,
+                "regimen_matrimonial": None,
+            },
             "contacto": {},
             "empleo": {},
-            "finanzas": {},
-            "plazo_credito": None,
-            "genero": None,
-            "estado_civil": None,
-            "regimen_matrimonial": None,
-            "tipo_propiedad": None,
-            "otros_ingresos": None,
-            "tipo_ingreso": None,
+            "finanzas": {
+                "plazo_credito": None,
+                "tipo_propiedad": None,
+                "otros_ingresos": None,
+                "tipo_ingreso": None,
+            },
         }
 
     def _finalize(self, structured: Dict, plazos: set, genero: Optional[str]) -> Dict:
         if plazos:
-            structured["plazo_credito"] = max(plazos, key=int)
+            structured["finanzas"]["plazo_credito"] = max(plazos, key=int)
         else:
-            structured["plazo_credito"] = ""
+            structured["finanzas"]["plazo_credito"] = ""
 
-        structured["genero"] = genero or ""
+        structured["datos_personales"]["genero"] = genero or ""
 
-        for key in ["regimen_matrimonial", "otros_ingresos", "tipo_ingreso", "estado_civil", "tipo_propiedad"]:
-            if structured[key] is None:
-                structured[key] = ""
+        for key in ["regimen_matrimonial", "estado_civil"]:
+            if structured["datos_personales"][key] is None:
+                structured["datos_personales"][key] = ""
+
+        for key in ["tipo_propiedad", "otros_ingresos", "tipo_ingreso", "plazo_credito"]:
+            if structured["finanzas"][key] is None:
+                structured["finanzas"][key] = ""
 
         for k, v in structured["finanzas"].items():
             structured["finanzas"][k] = str(v) if v is not None else ""
@@ -70,28 +81,30 @@ class BanorteCreditoFieldCorrector(FieldCorrector):
                 genero_detectado = "Masculino"
             elif any(et in clean_key for et in ["soltero", "casado", "unión libre", "divorciado", "viudo"]):
                 if self._is_selected(corrected_value):
-                    structured["estado_civil"] = key.strip().split()[0]
+                    structured["datos_personales"]["estado_civil"] = key.strip().split()[0]
             elif "sociedad conyugal" in clean_key and self._is_selected(corrected_value):
-                structured["regimen_matrimonial"] = "Sociedad Conyugal"
-            elif "separación de bienes" in clean_key and self._is_selected(corrected_value):
-                structured["regimen_matrimonial"] = "Separación de Bienes"
+                structured["datos_personales"]["regimen_matrimonial"] = "Sociedad Conyugal"
+            elif "separacion de bienes" in clean_key and self._is_selected(corrected_value):
+                structured["datos_personales"]["regimen_matrimonial"] = "Separación de Bienes"
+            elif "regimen matrimonial" in clean_key or "regimen patrimonial" in clean_key:
+                structured["datos_personales"]["regimen_matrimonial"] = corrected_value
             elif "propia" in clean_key and self._is_selected(corrected_value):
-                structured["tipo_propiedad"] = "Propia"
+                structured["finanzas"]["tipo_propiedad"] = "Propia"
             elif "rentada" in clean_key and self._is_selected(corrected_value):
-                structured["tipo_propiedad"] = "Rentada"
+                structured["finanzas"]["tipo_propiedad"] = "Rentada"
             elif "hipotecada" in clean_key and self._is_selected(corrected_value):
-                structured["tipo_propiedad"] = "Hipotecada"
+                structured["finanzas"]["tipo_propiedad"] = "Hipotecada"
             elif "de familiares" in clean_key and self._is_selected(corrected_value):
-                structured["tipo_propiedad"] = "De familiares"
+                structured["finanzas"]["tipo_propiedad"] = "De familiares"
             elif "otros ingresos" in clean_key:
                 if "no" in clean_key and self._is_selected(corrected_value):
-                    structured["otros_ingresos"] = "No"
+                    structured["finanzas"]["otros_ingresos"] = "No"
                 elif "sí" in clean_key and self._is_selected(corrected_value):
-                    structured["otros_ingresos"] = "Sí"
+                    structured["finanzas"]["otros_ingresos"] = "Sí"
             elif "asalariado" in clean_key and self._is_selected(corrected_value):
-                structured["tipo_ingreso"] = "Asalariado"
+                structured["finanzas"]["tipo_ingreso"] = "Asalariado"
             elif "honorarios" in clean_key and self._is_selected(corrected_value):
-                structured["tipo_ingreso"] = "Honorarios"
+                structured["finanzas"]["tipo_ingreso"] = "Honorarios"
             elif "sueldo mensual" in clean_key:
                 sueldo = re.sub(r"[^\d]", "", corrected_value)
                 structured["finanzas"]["sueldo_mensual"] = int(sueldo) if sueldo.isdigit() else None

--- a/app/services/field_correctors/basic_field_corrector.py
+++ b/app/services/field_correctors/basic_field_corrector.py
@@ -48,14 +48,20 @@ class BasicFieldCorrector(FieldCorrector):
             value = " ".join(part.capitalize() for part in value.split())
         elif any(t in key_lower for t in ["teléfono", "telefono", "celular"]):
             value = re.sub(r"[^\d]", "", value)
-            if len(value) < 10:
+            if len(value) != 10:
                 return None
         elif "monto" in key_lower:
             value = re.sub(r"[^\d]", "", value)
             if not value.isdigit():
                 return None
-        elif "r.f.c" in key_lower or "rfc" in key_lower or "curp" in key_lower:
+        elif "r.f.c" in key_lower or "rfc" in key_lower:
             value = re.sub(r"[\s.-]", "", value).upper()
+            if not re.fullmatch(r"[A-ZÑ&]{3,4}\d{6}[A-Z\d]{3}", value):
+                return None
+        elif "curp" in key_lower:
+            value = re.sub(r"[\s-]", "", value).upper()
+            if not re.fullmatch(r"[A-Z]{4}\d{6}[HM][A-Z]{5}[A-Z\d]{2}", value):
+                return None
         elif "c.p" in key_lower or "c\u00f3digo postal" in key_lower or "codigo postal" in key_lower:
             value = re.sub(r"[^\d]", "", value)
             if len(value) != 5:

--- a/tests/test_basic_field_corrector.py
+++ b/tests/test_basic_field_corrector.py
@@ -9,9 +9,13 @@ bc = BasicFieldCorrector()
     ('correo', 'bademail.com', None),
     ('teléfono', '55 123-45678', '5512345678'),
     ('teléfono', '55 123-4567', None),
+    ('teléfono', '55 1234 56789', None),
     ('monto', '$1,234', '1234'),
     ('nombre', ' josé pérez ', 'José Pérez'),
     ('r.f.c.', ' abcd-010101-xx1 ', 'ABCD010101XX1'),
+    ('rfc', 'BAD010101AA', None),
+    ('curp', 'LOAJ800101HDFRRN09', 'LOAJ800101HDFRRN09'),
+    ('curp', 'INVALIDCURP123', None),
     ('c.p.', ' 12,345 ', '12345'),
     ('otro', ' valor ', 'valor'),
 ])

--- a/tests/test_structured_cleaner.py
+++ b/tests/test_structured_cleaner.py
@@ -17,5 +17,5 @@ def test_transform_basic():
     assert result['datos_personales']['nombre'] == 'Juan'
     assert result['contacto']['email'] == 'test@mail.com'
     assert result['finanzas']['sueldo_mensual'] == '1000'
-    assert result['plazo_credito'] == '36'
-    assert result['genero'] == 'Masculino'
+    assert result['finanzas']['plazo_credito'] == '36'
+    assert result['datos_personales']['genero'] == 'Masculino'


### PR DESCRIPTION
## Summary
- improve phone, RFC and CURP validation logic
- normalize Banorte field keys and reorganize output
- update structured cleaner tests to match new format
- extend field corrector tests for new validations

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68586e2cbad48322a77ba5e6dd4a63a9