### PR TITLE
Fix phone and salary recognition

### DIFF
--- a/app/services/field_correctors/banorte_credito_cleaner.py
+++ b/app/services/field_correctors/banorte_credito_cleaner.py
@@ -105,14 +105,14 @@ class BanorteCreditoFieldCorrector(FieldCorrector):
                 structured["finanzas"]["tipo_ingreso"] = "Asalariado"
             elif "honorarios" in clean_key and self._is_selected(corrected_value):
                 structured["finanzas"]["tipo_ingreso"] = "Honorarios"
-            elif "sueldo mensual" in clean_key:
+            elif any(x in clean_key for x in ["sueldo mensual", "salario mensual"]):
                 from services.utils.normalization import parse_money
 
                 sueldo = parse_money(corrected_value)
                 structured["finanzas"]["sueldo_mensual"] = sueldo if sueldo else None
             elif any(x in clean_key for x in ["nombre", "apellido", "curp", "rfc"]):
                 structured["datos_personales"][clean_key] = corrected_value
-            elif any(x in clean_key for x in ["teléfono", "celular", "correo", "email"]):
+            elif any(x in clean_key for x in ["telefono", "teléfono", "celular", "correo", "email"]):
                 structured["contacto"][clean_key] = corrected_value
             elif any(x in clean_key for x in ["empresa", "puesto"]):
                 structured["empleo"][clean_key] = corrected_value

--- a/tests/test_structured_cleaner.py
+++ b/tests/test_structured_cleaner.py
@@ -30,3 +30,23 @@ def test_transform_salary_variants():
     }
     result = cleaner.transform(data)
     assert result['finanzas']['sueldo_mensual'] == '100000.00'
+
+
+def test_transform_salario_mensual():
+    cleaner = BanorteCreditoFieldCorrector()
+    data = {
+        'salario mensual': '$5,000',
+    }
+    result = cleaner.transform(data)
+    assert result['finanzas']['sueldo_mensual'] == '5000.00'
+
+
+def test_transform_phone_variants():
+    cleaner = BanorteCreditoFieldCorrector()
+    data = {
+        'telefono de casa': '55 1111 2222',
+        'teléfono oficina': '55 3333 4444',
+    }
+    result = cleaner.transform(data)
+    assert result['contacto']['telefono de casa'] == '5511112222'
+    assert result['contacto']['telefono oficina'] == '5533334444'


### PR DESCRIPTION
## Summary
- support `salario mensual` as an alias for salary
- detect phone fields even without accents
- add unit tests for salary alias and phone extraction

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858934bdf608322b2418e34b2c5105b