### PR TITLE
Fix duplicate key overwrite and accent checks

### DIFF
--- a/app/services/field_correctors/banorte_credito_cleaner.py
+++ b/app/services/field_correctors/banorte_credito_cleaner.py
@@ -79,7 +79,7 @@ class BanorteCreditoFieldCorrector(FieldCorrector):
                 genero_detectado = "Femenino"
             elif "masculino" in clean_key and self._is_selected(corrected_value):
                 genero_detectado = "Masculino"
-            elif any(et in clean_key for et in ["soltero", "casado", "unión libre", "divorciado", "viudo"]):
+            elif any(et in clean_key for et in ["soltero", "casado", "union libre", "divorciado", "viudo"]):
                 if self._is_selected(corrected_value):
                     structured["datos_personales"]["estado_civil"] = key.strip().split()[0]
             elif "sociedad conyugal" in clean_key and self._is_selected(corrected_value):
@@ -99,7 +99,7 @@ class BanorteCreditoFieldCorrector(FieldCorrector):
             elif "otros ingresos" in clean_key:
                 if "no" in clean_key and self._is_selected(corrected_value):
                     structured["finanzas"]["otros_ingresos"] = "No"
-                elif "sí" in clean_key and self._is_selected(corrected_value):
+                elif "si" in clean_key and self._is_selected(corrected_value):
                     structured["finanzas"]["otros_ingresos"] = "Sí"
             elif "asalariado" in clean_key and self._is_selected(corrected_value):
                 structured["finanzas"]["tipo_ingreso"] = "Asalariado"
@@ -112,11 +112,11 @@ class BanorteCreditoFieldCorrector(FieldCorrector):
                 structured["finanzas"]["sueldo_mensual"] = sueldo if sueldo else None
             elif any(x in clean_key for x in ["nombre", "apellido", "curp", "rfc"]):
                 structured["datos_personales"][clean_key] = corrected_value
-            elif any(x in clean_key for x in ["teléfono", "celular", "correo", "email"]):
+            elif any(x in clean_key for x in ["telefono", "celular", "correo", "email"]):
                 structured["contacto"][clean_key] = corrected_value
             elif any(x in clean_key for x in ["empresa", "puesto"]):
                 structured["empleo"][clean_key] = corrected_value
-            elif any(x in clean_key for x in ["monto", "nómina"]):
+            elif any(x in clean_key for x in ["monto", "nomina"]):
                 structured["finanzas"][clean_key] = corrected_value
             else:
                 structured["datos_personales"][clean_key] = corrected_value

--- a/app/services/ocr/textract/textract_block_parser.py
+++ b/app/services/ocr/textract/textract_block_parser.py
@@ -59,7 +59,12 @@ class TextractBlockParser:
                         if value_block:
                             value_text = self._get_text(value_block, block_map)
             if key_text:
-                field_dict[key_text] = value_text
+                # Keep the first non-empty value for a key
+                if key_text in field_dict:
+                    if not field_dict[key_text] and value_text:
+                        field_dict[key_text] = value_text
+                else:
+                    field_dict[key_text] = value_text
 
         self.logger.info("Key-value pairs extracted: %s", len(field_dict))
 


### PR DESCRIPTION
## Summary
- prevent empty duplicate values from overwriting valid ones in `TextractBlockParser`
- normalize accent usage in `BanorteCreditoFieldCorrector`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68589e40c65483229b07dbe5ac13c905