### PR TITLE
Handle duplicate keys in Textract parser

### DIFF
--- a/app/services/ocr/textract/textract_block_parser.py
+++ b/app/services/ocr/textract/textract_block_parser.py
@@ -59,9 +59,13 @@ class TextractBlockParser:
                         if value_block:
                             value_text = self._get_text(value_block, block_map)
             if key_text:
-                # Keep the first non-empty value for a key
+                # Prefer later non-empty values if existing value is empty or shorter
                 if key_text in field_dict:
-                    if not field_dict[key_text] and value_text:
+                    current = field_dict[key_text]
+                    if (
+                        value_text
+                        and (not current or len(value_text) > len(current))
+                    ):
                         field_dict[key_text] = value_text
                 else:
                     field_dict[key_text] = value_text

--- a/tests/test_textract_parser.py
+++ b/tests/test_textract_parser.py
@@ -25,3 +25,40 @@ def test_parser_combines_lines():
     assert result['Nombre'] == 'Juan'
     assert result['Apellido'] == 'Perez'
     assert result['Telefono'] == '1234567890'
+
+
+def test_parser_prefers_later_non_empty_value():
+    blocks = [
+        {
+            'Id': '1',
+            'BlockType': 'KEY_VALUE_SET',
+            'EntityTypes': ['KEY'],
+            'Relationships': [{'Type': 'CHILD', 'Ids': ['1w']}, {'Type': 'VALUE', 'Ids': ['2']}]
+        },
+        {'Id': '1w', 'BlockType': 'WORD', 'Text': 'E-mail'},
+        {
+            'Id': '2',
+            'BlockType': 'KEY_VALUE_SET',
+            'EntityTypes': ['VALUE'],
+            'Relationships': [{'Type': 'CHILD', 'Ids': ['2w']}]
+        },
+        {'Id': '2w', 'BlockType': 'WORD', 'Text': 'bad'},
+        {
+            'Id': '3',
+            'BlockType': 'KEY_VALUE_SET',
+            'EntityTypes': ['KEY'],
+            'Relationships': [{'Type': 'CHILD', 'Ids': ['3w']}, {'Type': 'VALUE', 'Ids': ['4']}]
+        },
+        {'Id': '3w', 'BlockType': 'WORD', 'Text': 'E-mail'},
+        {
+            'Id': '4',
+            'BlockType': 'KEY_VALUE_SET',
+            'EntityTypes': ['VALUE'],
+            'Relationships': [{'Type': 'CHILD', 'Ids': ['4w']}]
+        },
+        {'Id': '4w', 'BlockType': 'WORD', 'Text': 'good@example.com'}
+    ]
+
+    parser = TextractBlockParser()
+    result = parser.parse(blocks)
+    assert result['E-mail'] == 'good@example.com'


### PR DESCRIPTION
## Summary
- improve `TextractBlockParser.parse` so later non-empty values replace empty or shorter ones
- add regression test for duplicate key handling

## Testing
- `pytest tests/test_textract_parser.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858a31fb9408322b0f1b6caf332a250