### PR TITLE
Update UI with form editing and stub save

### DIFF
--- a/web/app.py
+++ b/web/app.py
@@ -1,11 +1,14 @@
 # web/app.py
-from flask import Flask, render_template, request
+from flask import Flask, render_template, request, jsonify
+import base64
 import requests
 from services.utils.logger import get_logger
+from services.db_client import DatabaseClient
 
 app = Flask(__name__, template_folder="templates")
 logger = get_logger(__name__)
 logger.info("Starting Flask app...")
+db_client = DatabaseClient()
 
 @app.route("/", methods=["GET", "POST"])
 def index():
@@ -15,10 +18,20 @@ def index():
         file = request.files["document"]
         if file:
             try:
-                response = requests.post("http://api:8000/api/analyze", files={"file": file})
+                file_bytes = file.read()
+                files = {"file": (file.filename, file_bytes, file.mimetype)}
+                response = requests.post("http://api:8000/api/analyze", files=files)
                 if response.ok:
                     data = response.json()
-                    return render_template("index.html", fields=data.get("fields", {}))
+                    b64_file = base64.b64encode(file_bytes).decode("utf-8")
+                    file_url = f"data:{file.mimetype};base64,{b64_file}"
+                    return render_template(
+                        "index.html",
+                        fields=data.get("fields", {}),
+                        file_url=file_url,
+                        is_pdf=file.mimetype == "application/pdf",
+                        form_type=data.get("form_type"),
+                    )
                 logger.error("Error en la API: %s %s", response.status_code, response.text)
                 return render_template("index.html", fields={}, error="Error al procesar el documento.")
             except Exception as exc:
@@ -27,7 +40,16 @@ def index():
 
     logger.info("Rendering index.html")
     # Si es una solicitud GET, renderizar el formulario
-    return render_template("index.html", fields={})
+    return render_template("index.html", fields={}, file_url=None, form_type=None)
+
+
+@app.route("/save", methods=["POST"])
+def save():
+    data = request.get_json() or {}
+    form_type = data.get("form_type")
+    fields = data.get("fields", {})
+    db_client.save_form(form_type, fields)
+    return jsonify({"status": "ok"})
 
 if __name__ == "__main__":
     app.run(host="0.0.0.0", port=5000)

--- a/web/services/db_client.py
+++ b/web/services/db_client.py
@@ -1,0 +1,13 @@
+from services.utils.logger import get_logger
+
+
+class DatabaseClient:
+    """Placeholder database client."""
+
+    def __init__(self):
+        self.logger = get_logger(self.__class__.__name__)
+
+    def save_form(self, form_type: str, fields: dict) -> None:
+        """Temporary stub that logs received data."""
+        self.logger.info("Saving form of type '%s' with %d fields", form_type, len(fields))
+

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -89,6 +89,16 @@
         .subsection {
             margin-left: 1em;
         }
+
+        .result-container {
+            display: flex;
+            gap: 2em;
+        }
+
+        .form-section,
+        .preview-section {
+            flex: 1;
+        }
     </style>
 </head>
 <body>
@@ -101,24 +111,44 @@
         <div id="spinner"></div>
 
         {% if fields %}
-            <h2>Resultados OCR</h2>
-
-            {% macro render_fields(data, level=0) %}
-            <ul class="{{ 'subsection' if level > 0 }}">
+            {% macro render_form(data, prefix='') %}
+            <div class="{{ 'subsection' if prefix }}">
                 {% for key, value in data.items() %}
+                    {% set field_name = (prefix ~ '.' if prefix else '') ~ key %}
                     {% if value is mapping %}
-                        <li>
-                            <div class="section-title">{{ key.replace('_', ' ').capitalize() }}</div>
-                            {{ render_fields(value, level + 1) }}
-                        </li>
+                        <fieldset>
+                            <legend class="section-title">{{ key.replace('_', ' ').capitalize() }}</legend>
+                            {{ render_form(value, field_name) }}
+                        </fieldset>
                     {% else %}
-                        <li><span class="field-key">{{ key.replace('_', ' ').capitalize() }}:</span> <span class="field-value">{{ value }}</span></li>
+                        <div>
+                            <label class="field-key">{{ key.replace('_', ' ').capitalize() }}:
+                                <input type="text" name="{{ field_name }}" value="{{ value }}">
+                            </label>
+                        </div>
                     {% endif %}
                 {% endfor %}
-            </ul>
+            </div>
             {% endmacro %}
 
-            {{ render_fields(fields) }}
+            <div class="result-container">
+                <div class="form-section">
+                    <h2>Editar Datos</h2>
+                    <form id="edit-form">
+                        {{ render_form(fields) }}
+                        <button type="button" id="save-btn">Guardar</button>
+                    </form>
+                </div>
+                <div class="preview-section">
+                    {% if file_url %}
+                        {% if is_pdf %}
+                            <embed src="{{ file_url }}" type="application/pdf" width="100%" height="600px" />
+                        {% else %}
+                            <img src="{{ file_url }}" alt="Documento" style="max-width:100%;" />
+                        {% endif %}
+                    {% endif %}
+                </div>
+            </div>
         {% endif %}
     </div>
     <script>
@@ -129,6 +159,39 @@
             setTimeout(function () {
                 form.submit();
             }, 10);
+        });
+
+        function buildPayload(form) {
+            const result = {};
+            const data = new FormData(form);
+            for (const [key, value] of data.entries()) {
+                const keys = key.split('.');
+                let obj = result;
+                keys.forEach((k, idx) => {
+                    if (idx === keys.length - 1) {
+                        obj[k] = value;
+                    } else {
+                        if (!obj[k]) obj[k] = {};
+                        obj = obj[k];
+                    }
+                });
+            }
+            return result;
+        }
+
+        document.getElementById('save-btn')?.addEventListener('click', function () {
+            const form = document.getElementById('edit-form');
+            const payload = {
+                form_type: "{{ form_type }}",
+                fields: buildPayload(form)
+            };
+            fetch('/save', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(payload)
+            }).then(r => r.json()).then(() => {
+                alert('Datos enviados para guardar');
+            });
         });
     </script>
 </body>


### PR DESCRIPTION
## Summary
- display processed document preview and editable form
- add placeholder db client to log save operations
- update Flask routes to send/receive data and handle saves

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68618561d22883229b74f724445f116f