### PR TITLE
Add SQLAlchemy model and DB saving

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,3 +14,6 @@ OPENAI_MODEL=gpt-3.5-turbo
 
 # HuggingFace
 HF_MODEL_NAME=dreuxx26/Multilingual-grammar-Corrector-using-mT5-small
+
+# Database
+DATABASE_URL=postgresql+psycopg2://user:password@db:5432/ocrdata

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ refinement.
 | `HF_MODEL_NAME` | Model name for HuggingFace refiner. |
 | `TEXTRACT_MAX_RETRIES` | Maximum polling attempts for Textract jobs. |
 | `TEXTRACT_SLEEP_SECONDS` | Delay between Textract polling attempts. |
+| `DATABASE_URL` | Connection string for PostgreSQL. Defaults to the local container URL. |
 
 ## Running the stack
 

--- a/web/Dockerfile.web
+++ b/web/Dockerfile.web
@@ -8,7 +8,7 @@ COPY . .
 
 # Instalar dependencias
 RUN pip install --upgrade pip && \
-    pip install --no-cache-dir flask requests
+    pip install --no-cache-dir flask requests sqlalchemy psycopg2-binary
 
 # Exponer puerto de Flask
 EXPOSE 5000

--- a/web/app.py
+++ b/web/app.py
@@ -48,7 +48,8 @@ def save():
     data = request.get_json() or {}
     form_type = data.get("form_type")
     fields = data.get("fields", {})
-    db_client.save_form(form_type, fields)
+    file_url = data.get("file_url")
+    db_client.save_form(form_type, fields, file_url)
     return jsonify({"status": "ok"})
 
 if __name__ == "__main__":

--- a/web/services/db_client.py
+++ b/web/services/db_client.py
@@ -1,13 +1,62 @@
+import os
+from typing import Any, Optional
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker, Session
+
 from services.utils.logger import get_logger
+from services.db_models import Base, CreditApplication
+
+DEFAULT_DB_URL = "postgresql+psycopg2://user:password@db:5432/ocrdata"
+
+
+def _extract(fields: dict, key: str) -> Optional[Any]:
+    """Recursively search a key in a nested dictionary."""
+    if key in fields:
+        return fields[key]
+    for value in fields.values():
+        if isinstance(value, dict):
+            found = _extract(value, key)
+            if found is not None:
+                return found
+    return None
 
 
 class DatabaseClient:
-    """Placeholder database client."""
+    """Persist credit applications to the database."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.logger = get_logger(self.__class__.__name__)
+        database_url = os.getenv("DATABASE_URL", DEFAULT_DB_URL)
+        self.engine = create_engine(database_url)
+        Base.metadata.create_all(self.engine)
+        self.SessionLocal = sessionmaker(bind=self.engine)
 
-    def save_form(self, form_type: str, fields: dict) -> None:
-        """Temporary stub that logs received data."""
-        self.logger.info("Saving form of type '%s' with %d fields", form_type, len(fields))
-
+    def save_form(self, form_type: str, fields: dict, file_url: Optional[str] = None) -> None:
+        session: Session = self.SessionLocal()
+        try:
+            record = CreditApplication(
+                tipo_credito=form_type,
+                nombre=_extract(fields, "nombre"),
+                apellido_paterno=_extract(fields, "apellido_paterno"),
+                apellido_materno=_extract(fields, "apellido_materno"),
+                rfc=_extract(fields, "rfc"),
+                curp=_extract(fields, "curp"),
+                fecha_nacimiento=_extract(fields, "fecha_nacimiento"),
+                monto_solicitado=_extract(fields, "monto_solicitado"),
+                ingresos_mensuales=_extract(fields, "ingresos_mensuales"),
+                riesgo_score=_extract(fields, "riesgo_score"),
+                riesgo_clase=_extract(fields, "riesgo_clase"),
+                extra_data=fields,
+                file_url=file_url,
+                status="nuevo",
+            )
+            session.add(record)
+            session.commit()
+            self.logger.info("Saved credit application %s", record.uuid)
+        except Exception as exc:  # pragma: no cover - minimal logging
+            session.rollback()
+            self.logger.error("Error saving application: %s", exc)
+            raise
+        finally:
+            session.close()

--- a/web/services/db_models.py
+++ b/web/services/db_models.py
@@ -1,0 +1,40 @@
+from datetime import datetime
+import uuid
+
+from sqlalchemy import (
+    Column,
+    Integer,
+    String,
+    Date,
+    DateTime,
+    Numeric,
+    text,
+)
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import declarative_base
+
+Base = declarative_base()
+
+class CreditApplication(Base):
+    __tablename__ = 'credit_applications'
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    uuid = Column(String, unique=True, default=lambda: str(uuid.uuid4()))
+    created_at = Column(DateTime(timezone=True), server_default=text('NOW()'))
+    updated_at = Column(DateTime(timezone=True), server_default=text('NOW()'), onupdate=datetime.utcnow)
+
+    tipo_credito = Column(String)
+    nombre = Column(String)
+    apellido_paterno = Column(String)
+    apellido_materno = Column(String)
+    rfc = Column(String)
+    curp = Column(String)
+    fecha_nacimiento = Column(Date)
+    monto_solicitado = Column(Numeric(12, 2))
+    ingresos_mensuales = Column(Numeric(12, 2))
+    riesgo_score = Column(Numeric(6, 2))
+    riesgo_clase = Column(String)
+    extra_data = Column(JSONB)
+    file_url = Column(String)
+    status = Column(String, default='nuevo')
+

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -208,7 +208,8 @@
             const form = document.getElementById('edit-form');
             const payload = {
                 form_type: "{{ form_type }}",
-                fields: buildPayload(form)
+                fields: buildPayload(form),
+                file_url: "{{ file_url|default('') }}"
             };
             fetch('/save', {
                 method: 'POST',


### PR DESCRIPTION
## Summary
- add `CreditApplication` SQLAlchemy model
- implement database client with SQLAlchemy to store credit applications
- allow `/save` endpoint to include file URL
- send file URL from the web form when saving
- document new `DATABASE_URL` environment variable
- update Dockerfile to install SQLAlchemy and psycopg2 dependencies

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861a154a1408322988cdcde47b0038c