### PR TITLE
Fix handling of multi-word fields

### DIFF
--- a/tests/test_db_client.py
+++ b/tests/test_db_client.py
@@ -1,0 +1,27 @@
+import sys
+from unittest.mock import MagicMock
+import os
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+sys.modules.setdefault('sqlalchemy', MagicMock())
+sys.modules.setdefault('sqlalchemy.orm', MagicMock())
+sys.modules.setdefault('sqlalchemy.dialects', MagicMock())
+sys.modules.setdefault('sqlalchemy.dialects.postgresql', MagicMock())
+sys.modules.setdefault('services.db_models', MagicMock())
+
+from web.services.db_client import _extract
+
+
+def test_extract_with_spaces():
+    fields = {
+        "datos_personales": {
+            "apellido paterno": "Perez",
+            "apellido_materno": "Lopez",
+        },
+        "finanzas": {
+            "monto solicitado": "1000"
+        }
+    }
+    assert _extract(fields, "apellido_paterno") == "Perez"
+    assert _extract(fields, "monto_solicitado") == "1000"
+

--- a/web/services/db_client.py
+++ b/web/services/db_client.py
@@ -5,6 +5,7 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker, Session
 
 from services.utils.logger import get_logger
+from services.utils.normalization import normalize_key
 from services.db_models import Base, CreditApplication
 
 DEFAULT_DB_URL = "postgresql+psycopg2://user:password@db:5432/ocrdata"
@@ -14,6 +15,13 @@ def _extract(fields: dict, key: str) -> Optional[Any]:
     """Recursively search a key in a nested dictionary."""
     if key in fields:
         return fields[key]
+
+    normalized_target = normalize_key(key)
+
+    for k, value in fields.items():
+        if normalize_key(k) == normalized_target:
+            return value
+
     for value in fields.values():
         if isinstance(value, dict):
             found = _extract(value, key)


### PR DESCRIPTION
## Summary
- normalize key names when extracting values before saving to DB
- add regression test for recursive extraction

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861b9faa62c8322aaee4b6eb70a992d