### PR TITLE
Fix module not found on web server

### DIFF
--- a/tests/test_db_client.py
+++ b/tests/test_db_client.py
@@ -1,0 +1,27 @@
+import sys
+from unittest.mock import MagicMock
+import os
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+sys.modules.setdefault('sqlalchemy', MagicMock())
+sys.modules.setdefault('sqlalchemy.orm', MagicMock())
+sys.modules.setdefault('sqlalchemy.dialects', MagicMock())
+sys.modules.setdefault('sqlalchemy.dialects.postgresql', MagicMock())
+sys.modules.setdefault('services.db_models', MagicMock())
+
+from web.services.db_client import _extract
+
+
+def test_extract_with_spaces():
+    fields = {
+        "datos_personales": {
+            "apellido paterno": "Perez",
+            "apellido_materno": "Lopez",
+        },
+        "finanzas": {
+            "monto solicitado": "1000"
+        }
+    }
+    assert _extract(fields, "apellido_paterno") == "Perez"
+    assert _extract(fields, "monto_solicitado") == "1000"
+

--- a/web/services/db_client.py
+++ b/web/services/db_client.py
@@ -5,6 +5,7 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker, Session
 
 from services.utils.logger import get_logger
+from services.utils.normalization import normalize_key
 from services.db_models import Base, CreditApplication
 
 DEFAULT_DB_URL = "postgresql+psycopg2://user:password@db:5432/ocrdata"
@@ -14,6 +15,13 @@ def _extract(fields: dict, key: str) -> Optional[Any]:
     """Recursively search a key in a nested dictionary."""
     if key in fields:
         return fields[key]
+
+    normalized_target = normalize_key(key)
+
+    for k, value in fields.items():
+        if normalize_key(k) == normalized_target:
+            return value
+
     for value in fields.values():
         if isinstance(value, dict):
             found = _extract(value, key)

--- a/web/services/utils/normalization.py
+++ b/web/services/utils/normalization.py
@@ -1,0 +1,53 @@
+import re
+import unicodedata
+from typing import Optional
+
+def normalize_key(key: str) -> str:
+    """Normalize dictionary keys to snake_case."""
+    key = key.strip().lower()
+    # Normalize accented characters like "ó" -> "o" and "ñ" -> "n"
+    key = "".join(
+        c for c in unicodedata.normalize("NFKD", key) if not unicodedata.combining(c)
+    )
+    # Preserve slashes but collapse surrounding whitespace
+    key = re.sub(r"\s*/\s*", "/", key)
+    # Replace spaces and hyphens with underscores
+    key = re.sub(r"[\s\-]+", "_", key)
+    # Remove remaining unwanted characters except underscores and slashes
+    key = re.sub(r"[^a-z0-9/_]", "", key)
+    key = re.sub(r"_+", "_", key)
+    return key.strip("_")
+
+
+def parse_money(amount: str) -> Optional[str]:
+    """Return a monetary value as a string with two decimals.
+
+    Supports inputs with mixed comma and period usage such as ``1.000.00`` or
+    ``1,000,00`` that may result from OCR errors. If the last punctuation
+    character is followed by one or two digits it is treated as the decimal
+    separator. All preceding punctuation characters are considered thousand
+    separators and removed. Returns ``None`` when the value cannot be parsed.
+    """
+
+    if not amount:
+        return None
+
+    amt = amount.strip().replace("$", "").replace(" ", "")
+
+    # Identify the last comma or period in the string
+    m = re.search(r"[.,](?=[^.,]*$)", amt)
+    if m:
+        dec_index = m.start()
+        decimals = amt[dec_index + 1:]
+        if decimals.isdigit() and 0 < len(decimals) <= 2:
+            integer = re.sub(r"[.,]", "", amt[:dec_index])
+            amt = f"{integer}.{decimals}"
+        else:
+            amt = re.sub(r"[.,]", "", amt)
+    else:
+        amt = re.sub(r"[.,]", "", amt)
+
+    try:
+        return f"{float(amt):.2f}"
+    except ValueError:
+        return None


### PR DESCRIPTION
## Summary
- provide `normalize_key` and `parse_money` utilities inside the web package

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6861b9faa62c8322aaee4b6eb70a992d