### PR TITLE
Update UI to preview immediately while processing

### DIFF
--- a/web/static/main.js
+++ b/web/static/main.js
@@ -1,17 +1,88 @@
+async function fileToDataURL(file) {
+    return new Promise((resolve, reject) => {
+        const reader = new FileReader();
+        reader.onload = () => resolve(reader.result);
+        reader.onerror = reject;
+        reader.readAsDataURL(file);
+    });
+}
+
+function prettify(key) {
+    const str = key.replace(/_/g, ' ');
+    return str.charAt(0).toUpperCase() + str.slice(1);
+}
+
+function renderFields(data, prefix = '') {
+    let html = `<div class="${prefix ? 'subsection' : ''}">`;
+    Object.entries(data).forEach(([key, value]) => {
+        const fieldName = prefix ? `${prefix}.${key}` : key;
+        if (value && typeof value === 'object' && !Array.isArray(value)) {
+            html += `<fieldset><legend class="section-title">${prettify(key)}</legend>`;
+            html += renderFields(value, fieldName);
+            html += `</fieldset>`;
+        } else {
+            html += `<div><label class="field-key">${prettify(key)}:` +
+                ` <input type="text" name="${fieldName}" value="${value}"></label></div>`;
+        }
+    });
+    html += '</div>';
+    return html;
+}
+
+function showPreview(file) {
+    const previewArea = document.getElementById('preview-area');
+    previewArea.innerHTML = '';
+    if (file.type === 'application/pdf') {
+        const url = URL.createObjectURL(file);
+        previewArea.innerHTML = `<iframe src="${url}" width="100%" height="600px"></iframe>`;
+    } else {
+        const reader = new FileReader();
+        reader.onload = e => {
+            previewArea.innerHTML = `<div id="image-container"><img id="preview-image" ` +
+                `src="${e.target.result}" alt="Documento" style="max-width:100%;" /></div>`;
+            setupImagePanZoom();
+        };
+        reader.readAsDataURL(file);
+    }
+}
+
 function setupUploadForm() {
     const uploadForm = document.getElementById('upload-form');
     if (!uploadForm) return;
-    uploadForm.addEventListener('submit', function (e) {
+    uploadForm.addEventListener('submit', async function (e) {
         e.preventDefault();
+        const fileInput = uploadForm.querySelector('input[name="document"]');
+        if (!fileInput.files.length) return;
+        const file = fileInput.files[0];
+
         document.getElementById('spinner').style.display = 'block';
-        const res = document.querySelector('.result-container');
-        if (res) res.remove();
-        const err = document.querySelector('.error');
-        if (err) err.remove();
-        const form = e.target;
-        setTimeout(function () {
-            form.submit();
-        }, 10);
+        document.getElementById('result-container').style.display = 'flex';
+        document.getElementById('save-btn').style.display = 'none';
+
+        showPreview(file);
+        const fileUrl = await fileToDataURL(file);
+        window.currentFileUrl = fileUrl;
+
+        const formData = new FormData();
+        formData.append('file', file);
+
+        try {
+            const res = await fetch('http://localhost:8000/api/analyze', {
+                method: 'POST',
+                body: formData
+            });
+            if (!res.ok) throw new Error('API error');
+            const data = await res.json();
+            window.formType = data.form_type;
+            document.getElementById('form-area').innerHTML = renderFields(data.fields);
+            document.getElementById('spinner').style.display = 'none';
+            document.getElementById('save-btn').style.display = 'block';
+            setupSaveButton(window.formType, window.currentFileUrl);
+        } catch (err) {
+            console.error(err);
+            document.getElementById('spinner').style.display = 'none';
+            alert('Error al procesar el documento');
+        }
     });
 }
 
@@ -94,8 +165,11 @@ function setupImagePanZoom() {
 
 function init(formType, fileUrl) {
     setupUploadForm();
-    setupSaveButton(formType, fileUrl);
-    setupImagePanZoom();
+    if (formType && fileUrl) {
+        setupSaveButton(formType, fileUrl);
+        setupImagePanZoom();
+        document.getElementById('result-container').style.display = 'flex';
+    }
 }
 
 document.addEventListener('DOMContentLoaded', () => init(window.formType, window.fileUrl));

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -7,56 +7,60 @@
         <button type="submit">Enviar</button>
     </form>
     <div id="spinner"></div>
+    <div id="result-container" class="result-container" {% if not fields %}style="display:none;"{% endif %}>
+        <div class="form-section">
+            <h2>Editar Datos</h2>
+            <form id="edit-form">
+                <div id="form-area">
+                {% if fields %}
+                    {% macro render_form(data, prefix='') %}
+                    <div class="{{ 'subsection' if prefix }}">
+                        {% for key, value in data.items() %}
+                            {% set field_name = (prefix ~ '.' if prefix else '') ~ key %}
+                            {% if value is mapping %}
+                                <fieldset>
+                                    <legend class="section-title">{{ key.replace('_', ' ').capitalize() }}</legend>
+                                    {{ render_form(value, field_name) }}
+                                </fieldset>
+                            {% else %}
+                                <div>
+                                    <label class="field-key">{{ key.replace('_', ' ').capitalize() }}:
+                                        <input type="text" name="{{ field_name }}" value="{{ value }}">
+                                    </label>
+                                </div>
+                            {% endif %}
+                        {% endfor %}
+                    </div>
+                    {% endmacro %}
+                    {{ render_form(fields) }}
+                {% endif %}
+                </div>
+                <button type="button" id="save-btn" {% if not fields %}style="display:none;"{% endif %}>Guardar</button>
+            </form>
+        </div>
+        <div class="preview-section">
+            <h2>Visor de Documento</h2>
+            <div id="preview-area">
+            {% if file_url %}
+                {% if is_pdf %}
+                    <iframe src="{{ file_url }}" width="100%" height="600px"></iframe>
+                {% else %}
+                    <div id="image-container">
+                        <img id="preview-image" src="{{ file_url }}" alt="Documento" style="max-width:100%;" />
+                    </div>
+                {% endif %}
+            {% endif %}
+            </div>
+        </div>
+    </div>
     {% if error %}
         <div class="error">{{ error }}</div>
     {% endif %}
-    {% if fields %}
-        {% macro render_form(data, prefix='') %}
-        <div class="{{ 'subsection' if prefix }}">
-            {% for key, value in data.items() %}
-                {% set field_name = (prefix ~ '.' if prefix else '') ~ key %}
-                {% if value is mapping %}
-                    <fieldset>
-                        <legend class="section-title">{{ key.replace('_', ' ').capitalize() }}</legend>
-                        {{ render_form(value, field_name) }}
-                    </fieldset>
-                {% else %}
-                    <div>
-                        <label class="field-key">{{ key.replace('_', ' ').capitalize() }}:
-                            <input type="text" name="{{ field_name }}" value="{{ value }}">
-                        </label>
-                    </div>
-                {% endif %}
-            {% endfor %}
-        </div>
-        {% endmacro %}
-        <div class="result-container">
-            <div class="form-section">
-                <h2>Editar Datos</h2>
-                <form id="edit-form">
-                    {{ render_form(fields) }}
-                    <button type="button" id="save-btn">Guardar</button>
-                </form>
-            </div>
-            <div class="preview-section">
-                <h2>Visor de Documento</h2>
-                {% if file_url %}
-                    {% if is_pdf %}
-                        <iframe src="{{ file_url }}" width="100%" height="600px"></iframe>
-                    {% else %}
-                        <div id="image-container">
-                            <img id="preview-image" src="{{ file_url }}" alt="Documento" style="max-width:100%;" />
-                        </div>
-                    {% endif %}
-                {% endif %}
-            </div>
-        </div>
-    {% endif %}
 {% endblock %}
 {% block scripts %}
+<script src="{{ url_for('static', filename='main.js') }}"></script>
 <script>
     window.formType = "{{ form_type }}";
     window.fileUrl = "{{ file_url|default('') }}";
 </script>
-<script src="{{ url_for('static', filename='main.js') }}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- display empty result container on form load
- show selected file preview immediately
- process file via API using JS and build dynamic form
- hide save button until fields are ready

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686826dfeaa88322811c86c10b199776