### PR TITLE
Improve save alert

### DIFF
--- a/web/app.py
+++ b/web/app.py
@@ -68,8 +68,15 @@ def save():
     form_type = data.get("form_type")
     fields = data.get("fields", {})
     file_url = data.get("file_url")
-    db_client.save_form(form_type, fields, file_url)
-    return jsonify({"status": "ok"})
+    try:
+        db_client.save_form(form_type, fields, file_url)
+        return jsonify({"status": "ok", "message": "Registro guardado correctamente"})
+    except Exception as exc:  # pragma: no cover - just logging
+        logger.error("Error saving form: %s", exc)
+        return (
+            jsonify({"status": "error", "message": "Error al guardar en la base de datos"}),
+            500,
+        )
 
 
 @app.route("/applications", methods=["GET"])

--- a/web/static/main.css
+++ b/web/static/main.css
@@ -112,3 +112,24 @@ table { width: 100%; border-collapse: collapse; }
 th, td { padding: 0.5em; border: 1px solid #ddd; text-align: left; }
 th { background-color: #f5f5f5; }
 .table-link { color: #2c3e50; text-decoration: none; }
+
+/* Alert styles */
+.alert {
+    margin: 1em auto;
+    padding: 1em;
+    border-radius: 4px;
+    width: 90%;
+    text-align: center;
+}
+
+.alert-success {
+    background-color: #d4edda;
+    color: #155724;
+    border: 1px solid #c3e6cb;
+}
+
+.alert-error {
+    background-color: #f8d7da;
+    color: #721c24;
+    border: 1px solid #f5c6cb;
+}

--- a/web/static/main.js
+++ b/web/static/main.js
@@ -7,6 +7,15 @@ async function fileToDataURL(file) {
     });
 }
 
+function showAlert(message, success = true) {
+    const box = document.getElementById('alert-container');
+    if (!box) return;
+    box.textContent = message;
+    box.className = success ? 'alert alert-success' : 'alert alert-error';
+    box.style.display = 'block';
+    setTimeout(() => { box.style.display = 'none'; }, 3000);
+}
+
 function prettify(key) {
     const str = key.replace(/_/g, ' ');
     return str.charAt(0).toUpperCase() + str.slice(1);
@@ -141,9 +150,19 @@ function setupSaveButton(formType, fileUrl) {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify(payload)
-        }).then(r => r.json()).then(() => {
-            alert('Datos enviados para guardar');
-        });
+        })
+            .then(res => res.json().then(data => ({ ok: res.ok, data })))
+            .then(({ ok, data }) => {
+                if (ok && data.status === 'ok') {
+                    showAlert(data.message || 'Registro guardado', true);
+                } else {
+                    throw new Error(data.message || 'Error al guardar');
+                }
+            })
+            .catch(err => {
+                console.error(err);
+                showAlert(err.message || 'Error al guardar', false);
+            });
     };
 }
 

--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -12,6 +12,7 @@
         <a href="/applications">Consultas</a>
         <a href="/help">Ayuda</a>
     </nav>
+    <div id="alert-container" class="alert" style="display:none;"></div>
     <div class="container">
         {% block content %}{% endblock %}
     </div>


### PR DESCRIPTION
## Summary
- add alert container to base template
- style success and error alerts
- show alert messages when saving forms
- handle errors when saving forms

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68686bb4fd148322ad3d44da7e297fcd