### PR TITLE
Improve hipotecario field mapping

### DIFF
--- a/app/examples/analyzeDocResponse.json
+++ b/app/examples/analyzeDocResponse.json
@@ -1,0 +1,1 @@
+{"Blocks": [{"BlockType": "LINE", "Text": "CRÉDITO PERSONAL BANORTE", "Page": 1}]}

--- a/tests/test_hipotecario_cleaner.py
+++ b/tests/test_hipotecario_cleaner.py
@@ -33,3 +33,14 @@ def test_transform_aliases():
     assert result["datos_personales"]["curp"] == "LOAJ800101HDFRRN09"
     assert result["datos_personales"]["rfc"] == "ABCD900101XX1"
 
+
+def test_transform_razon_social_and_trailing_digits():
+    cleaner = HipotecarioFieldCorrector()
+    data = {
+        "Nombre / Razón social": "Juan Perez",
+        "Teléfono celular452 147 1121": "",
+    }
+    result = cleaner.transform(data)
+    assert result["datos_personales"]["nombre"] == "Juan Perez"
+    assert result["contacto"]["telefono_celular"] == "4521471121"
+


### PR DESCRIPTION
## Summary
- expand key normalization for credito hipotecario forms
- handle aliases like `nombre(s)`, `1er apellido`, `2do apellido`, `CURP`, `RFC`
- test these additional aliases

## Testing
- `pytest tests/test_hipotecario_cleaner.py -q`
- `pytest -q` *(fails: FileNotFoundError: analyzeDocResponse.json)*

------
https://chatgpt.com/codex/tasks/task_e_68695bc792bc83229b8e6bdf3ae86e07