### PR TITLE
Fix pydantic validation for mixed type fields

### DIFF
--- a/app/models/data_response.py
+++ b/app/models/data_response.py
@@ -5,4 +5,4 @@ from pydantic import BaseModel
 class DataResponse(BaseModel):
     form_type: str
     filename: str
-    fields: Dict[str, Union[str, Dict[str, str]]]
+    fields: Dict[str, Union[str, Dict[str, str], int, float, None]]

--- a/app/models/ocr_response.py
+++ b/app/models/ocr_response.py
@@ -5,4 +5,4 @@ from typing import Dict, Union
 
 class OCRResponse(BaseModel):
     form_name: str
-    fields: Dict[str, Union[str, Dict[str, str]]]
+    fields: Dict[str, Union[str, Dict[str, str], int, float, None]]


### PR DESCRIPTION
## Summary
- loosen OCRResponse and DataResponse field types

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869d4a387f08322af8c0059fcb8770e