### PR TITLE
Fix pydantic validation for mixed type fields

### DIFF
--- a/app/interfaces/field_corrector.py
+++ b/app/interfaces/field_corrector.py
@@ -1,12 +1,12 @@
 # app/interfaces/field_corrector.py
 from abc import ABC, abstractmethod
-from typing import Optional
+from typing import Optional, Any
 
 
 class FieldCorrector(ABC):
     """Interfaz para aplicar correcciones a valores individuales."""
 
     @abstractmethod
-    def correct(self, key: str, value: str) -> Optional[str]:
+    def correct(self, key: str, value: Any) -> Optional[str]:
         """Recibe el nombre del campo y retorna el valor corregido o None."""
         pass

--- a/app/models/data_response.py
+++ b/app/models/data_response.py
@@ -5,4 +5,4 @@ from pydantic import BaseModel
 class DataResponse(BaseModel):
     form_type: str
     filename: str
-    fields: Dict[str, Union[str, Dict[str, str]]]
+    fields: Dict[str, Union[str, Dict[str, str], int, float, None]]

--- a/app/models/ocr_response.py
+++ b/app/models/ocr_response.py
@@ -5,4 +5,4 @@ from typing import Dict, Union
 
 class OCRResponse(BaseModel):
     form_name: str
-    fields: Dict[str, Union[str, Dict[str, str]]]
+    fields: Dict[str, Union[str, Dict[str, str], int, float, None]]

--- a/app/services/field_correctors/banorte_credito_cleaner.py
+++ b/app/services/field_correctors/banorte_credito_cleaner.py
@@ -2,7 +2,7 @@
 
 import re
 import unicodedata
-from typing import Optional, Dict
+from typing import Optional, Dict, Any
 from interfaces.field_corrector import FieldCorrector
 from services.field_correctors.basic_field_corrector import BasicFieldCorrector
 
@@ -21,7 +21,7 @@ class BanorteCreditoFieldCorrector(FieldCorrector):
     def _is_selected(self, value: str) -> bool:
         return "[x]" in value.lower()
 
-    def correct(self, key: str, value: str) -> Optional[str]:
+    def correct(self, key: str, value: Any) -> Optional[str]:
         return self.basic.correct(key, value)
 
     def _init_structured(self) -> Dict:

--- a/app/services/field_correctors/basic_field_corrector.py
+++ b/app/services/field_correctors/basic_field_corrector.py
@@ -1,7 +1,7 @@
 # app/services/field_correctors/basic_field_corrector.py
 
 import re
-from typing import Optional
+from typing import Optional, Any
 from interfaces.field_corrector import FieldCorrector
 
 
@@ -30,7 +30,11 @@ class BasicFieldCorrector(FieldCorrector):
             return "".join(corrected)
         return text
 
-    def correct(self, key: str, value: str) -> Optional[str]:
+    def correct(self, key: str, value: Any) -> Optional[str]:
+        if value is None:
+            return None
+        if not isinstance(value, str):
+            value = str(value)
         value = re.sub(r"\s+", " ", value).strip()
         if not value:
             return None

--- a/app/services/field_correctors/hipotecario_cleaner.py
+++ b/app/services/field_correctors/hipotecario_cleaner.py
@@ -1,4 +1,4 @@
-from typing import Dict, Optional
+from typing import Dict, Optional, Any
 import re
 import unicodedata
 from interfaces.field_corrector import FieldCorrector
@@ -11,7 +11,7 @@ class HipotecarioFieldCorrector(FieldCorrector):
     def __init__(self) -> None:
         self.basic = BasicFieldCorrector()
 
-    def correct(self, key: str, value: str) -> Optional[str]:
+    def correct(self, key: str, value: Any) -> Optional[str]:
         return self.basic.correct(key, value)
 
     def _clean_key(self, key: str) -> str:

--- a/app/services/postprocessors/basic_postprocessor.py
+++ b/app/services/postprocessors/basic_postprocessor.py
@@ -1,4 +1,4 @@
-from typing import Dict
+from typing import Dict, Any
 from interfaces.postprocessor import PostProcessor
 from services.field_correctors.basic_field_corrector import BasicFieldCorrector
 from services.utils.normalization import normalize_key
@@ -8,7 +8,7 @@ class BasicPostProcessor(PostProcessor):
     def __init__(self):
         self.corrector = BasicFieldCorrector()
 
-    def process(self, fields: Dict[str, str]) -> Dict:
+    def process(self, fields: Dict[str, Any]) -> Dict:
         processed: Dict[str, str] = {}
         for key, value in fields.items():
             clean = self.corrector.correct(key, value)


### PR DESCRIPTION
## Summary
- loosen OCRResponse and DataResponse field types
- allow BasicFieldCorrector to clean non-string data

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6869d4a387f08322af8c0059fcb8770e