### PR TITLE
Fix OCR response model validation

### DIFF
--- a/app/models/data_response.py
+++ b/app/models/data_response.py
@@ -1,8 +1,9 @@
-from typing import Dict, Union
+from typing import Dict, Any
 from pydantic import BaseModel
 
 
 class DataResponse(BaseModel):
     form_type: str
     filename: str
-    fields: Dict[str, Union[str, Dict[str, str], int, float, None]]
+    # Use a generic mapping for fields returned to clients
+    fields: Dict[str, Any]

--- a/app/models/ocr_response.py
+++ b/app/models/ocr_response.py
@@ -1,8 +1,9 @@
 # app/models/ocr_response.py
 from pydantic import BaseModel
-from typing import Dict, Union
+from typing import Dict, Any
 
 
 class OCRResponse(BaseModel):
     form_name: str
-    fields: Dict[str, Union[str, Dict[str, str], int, float, None]]
+    # Allow nested dictionaries or mixed value types extracted from OCR
+    fields: Dict[str, Any]


### PR DESCRIPTION
## Summary
- expand `fields` in `OCRResponse` and `DataResponse` models to accept any type

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869e2d2633883229904b0fffbc01835