### PR TITLE
Implement postprocess and UI update

### DIFF
--- a/app/services/ocr_processor.py
+++ b/app/services/ocr_processor.py
@@ -2,6 +2,7 @@ from typing import Dict
 from fastapi import UploadFile
 from services.factory import get_ocr_service
 from services.utils.logger import get_logger
+from services.utils import postprocess_fields
 
 
 class OCRProcessor:
@@ -15,5 +16,6 @@ class OCRProcessor:
         """Analyze a file and return the extracted fields."""
         self.logger.info("Starting analysis for %s", file.filename)
         raw = await self.ocr_service.analyze(file)
-        return {"form_type": raw.form_name, "fields": raw.fields}
+        cleaned = postprocess_fields(raw.fields)
+        return {"form_type": raw.form_name, "fields": cleaned}
 

--- a/app/services/utils/__init__.py
+++ b/app/services/utils/__init__.py
@@ -1,0 +1,3 @@
+from .logger import get_logger
+from .normalization import normalize_key, parse_money
+from .postprocess import postprocess_fields

--- a/app/services/utils/postprocess.py
+++ b/app/services/utils/postprocess.py
@@ -1,0 +1,43 @@
+import re
+from typing import Any
+
+
+def _simplify(data: Any) -> Any:
+    """Convert lists of {label/name, value} pairs to dictionaries."""
+    if isinstance(data, list):
+        if all(isinstance(item, dict) and 'value' in item and ('label' in item or 'name' in item)
+               for item in data):
+            return { (item.get('label') or item.get('name')): _simplify(item.get('value')) for item in data }
+        return [_simplify(item) for item in data]
+    if isinstance(data, dict):
+        simplified = {k: _simplify(v) for k, v in data.items()}
+        if len(simplified) == 1:
+            return next(iter(simplified.values()))
+        return simplified
+    return data
+
+
+def _clean_value(val: Any) -> Any:
+    if isinstance(val, str):
+        cleaned = val.strip()
+        if '@' in cleaned:
+            cleaned = cleaned.lower()
+        digits = re.sub(r'\D', '', cleaned)
+        if digits and len(digits) >= 7 and len(digits) >= len(cleaned.replace(' ', '').replace('-', '')):
+            cleaned = digits
+        return cleaned
+    return val
+
+
+def _apply_cleaning(data: Any) -> Any:
+    if isinstance(data, dict):
+        return {k: _apply_cleaning(v) for k, v in data.items()}
+    if isinstance(data, list):
+        return [_apply_cleaning(v) for v in data]
+    return _clean_value(data)
+
+
+def postprocess_fields(fields: dict) -> dict:
+    """Simplify and clean OCR result fields."""
+    simplified = _simplify(fields)
+    return _apply_cleaning(simplified)

--- a/tests/test_gemini_service.py
+++ b/tests/test_gemini_service.py
@@ -17,6 +17,7 @@ sys.modules.setdefault('boto3', MagicMock())
 
 from services.factory import get_ocr_service  # noqa: E402
 from services.ocr.gemini.gemini_service import GeminiOCRService  # noqa: E402
+from services.ocr_processor import OCRProcessor  # noqa: E402
 from models import OCRResponse  # noqa: E402
 from fastapi import UploadFile  # noqa: E402
 from starlette.datastructures import Headers  # noqa: E402
@@ -50,7 +51,9 @@ def test_gemini_analyze(monkeypatch):
     result = asyncio.run(service.analyze(upload))
 
     assert isinstance(result, OCRResponse)
-    assert result.fields == {"Nombre": "Juan"}
+    assert result.fields == {
+        "datos personales": [{"label": "Nombre", "value": "Juan"}]
+    }
     fake_genai.upload_file.assert_called()
     fake_genai.get_file.assert_called()
     mock_model.generate_content.assert_called()
@@ -79,7 +82,40 @@ def test_gemini_analyze_name_key(monkeypatch):
     result = asyncio.run(service.analyze(upload))
 
     assert isinstance(result, OCRResponse)
-    assert result.fields == {"Monto": "100"}
+    assert result.fields == {"datos": [{"name": "Monto", "value": "100"}]}
     fake_genai.upload_file.assert_called()
     fake_genai.get_file.assert_called()
     mock_model.generate_content.assert_called()
+
+
+def test_processor_cleans_fields(monkeypatch):
+    mock_model = MagicMock()
+    mock_text = """```json
+{\n  \"datos\": [{\"label\": \"Nombre\", \"value\": \"Ana\"}]}\n```"""
+    mock_response = MagicMock(text=mock_text)
+    mock_model.generate_content.return_value = mock_response
+
+    fake_file = MagicMock()
+    fake_genai.upload_file.return_value = fake_file
+    fake_genai.get_file.return_value = fake_file
+
+    async def sync_to_thread(func, *a, **k):
+        return func(*a, **k)
+
+    monkeypatch.setattr(asyncio, "to_thread", sync_to_thread)
+
+    service = GeminiOCRService(api_key='key')
+    service.model = mock_model
+
+    def get_service(name=None):
+        return service
+
+    monkeypatch.setattr("services.ocr_processor.get_ocr_service", get_service)
+
+    headers = Headers({'content-type': 'image/png'})
+    upload = UploadFile(BytesIO(b'data'), filename='test.png', headers=headers)
+
+    processor = OCRProcessor()
+    result = asyncio.run(processor.analyze(upload))
+
+    assert result == {"form_type": "", "fields": {"Nombre": "Ana"}}

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -1,4 +1,9 @@
 {% extends "base.html" %}
+{% set FORM_NAMES = {
+    'credito_personal': 'Solicitud de Crédito Personal',
+    'credito_hipotecario': 'Solicitud de Crédito Hipotecario',
+    'credito_tarjeta': 'Solicitud de Tarjeta de Crédito'
+} %}
 {% block title %}Inicio{% endblock %}
 {% block content %}
     <h1>Sube un documento de solicitud</h1>
@@ -10,6 +15,9 @@
             <div class="form-section">
                 <div id="spinner"></div>
                 <h2>Editar Datos</h2>
+                {% if form_type %}
+                <h3>{{ FORM_NAMES.get(form_type, form_type.replace('_', ' ').title()) }}</h3>
+                {% endif %}
                 <form id="edit-form" {% if not fields %}style="display:none;"{% endif %}>
                 <div id="form-area">
                 {% if fields %}


### PR DESCRIPTION
## Summary
- add `postprocess_fields` utility for cleanup of OCR results
- run postprocess step in OCR processor
- show human readable form title on the UI
- remove duplicate cleaning call inside Gemini service
- update tests for new OCRProcessor behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686ab3bf20488322874aad54b6234b47