### PR TITLE
Implement Textract OCR service

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,5 +2,11 @@
 GEMINI_API_KEY=your-gemini-key
 GEMINI_MODEL=gemini-2.0-flash-thinking-exp-1219
 
+# OCR selection: gemini or textract
+OCR_SERVICE=gemini
+
+# AWS configuration for Textract
+AWS_REGION=us-east-1
+
 # Database
 DATABASE_URL=postgresql+psycopg2://user:password@db:5432/ocrdata

--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ documents and visualize the resulting fields.
 | -------- | ----------- |
 | `GEMINI_API_KEY` | API key for Gemini OCR. |
 | `GEMINI_MODEL` | Model name for Gemini OCR. |
+| `OCR_SERVICE` | Which OCR backend to use: `gemini` or `textract`. |
+| `AWS_REGION` | AWS region for Textract if using that backend. |
 | `DATABASE_URL` | Connection string for PostgreSQL. Defaults to the local container URL. |
 
 ## Running the stack

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -6,6 +6,7 @@ requests
 pydantic
 python-multipart
 python-magic
+amazon-textract-response-parser
 transformers
 torch
 protobuf>=3.20

--- a/app/services/factory.py
+++ b/app/services/factory.py
@@ -1,11 +1,14 @@
 # app/services/factory.py
+import os
 from services.ocr.gemini import GeminiOCRService
+from services.ocr.textract import TextractOCRService
 from interfaces.ocr_service import OCRService
 
 
 def get_ocr_service(service: str | None = None) -> OCRService:
-    """Return the configured OCR service.
+    """Return the configured OCR service."""
 
-    Only Gemini is supported in this simplified version.
-    """
+    name = (service or os.getenv("OCR_SERVICE", "gemini")).lower()
+    if name == "textract":
+        return TextractOCRService()
     return GeminiOCRService()

--- a/app/services/ocr/__init__.py
+++ b/app/services/ocr/__init__.py
@@ -1,0 +1,4 @@
+from .gemini import GeminiOCRService
+from .textract import TextractOCRService
+
+__all__ = ['GeminiOCRService', 'TextractOCRService']

--- a/app/services/ocr/textract/__init__.py
+++ b/app/services/ocr/textract/__init__.py
@@ -1,0 +1,2 @@
+__all__ = ["TextractOCRService"]
+from .textract_service import TextractOCRService

--- a/app/services/ocr/textract/textract_service.py
+++ b/app/services/ocr/textract/textract_service.py
@@ -1,0 +1,38 @@
+# services/ocr/textract/textract_service.py
+import os
+import asyncio
+from fastapi import UploadFile
+from interfaces.ocr_service import OCRService
+from models import OCRResponse
+from services.utils.logger import get_logger
+from trp import Document
+import boto3
+
+
+class TextractOCRService(OCRService):
+    """Extract fields using Amazon Textract."""
+
+    def __init__(self, region: str | None = None) -> None:
+        self.logger = get_logger(self.__class__.__name__)
+        region = region or os.getenv("AWS_REGION")
+        self.client = boto3.client("textract", region_name=region)
+
+    async def analyze(self, file: UploadFile) -> OCRResponse:
+        self.logger.info("Analyzing file with Textract: %s", file.filename)
+        data = await file.read()
+        response = await asyncio.to_thread(
+            self.client.analyze_document,
+            Document={"Bytes": data},
+            FeatureTypes=["FORMS"],
+        )
+
+        doc = Document(response)
+        fields: dict[str, str] = {}
+        for page in doc.pages:
+            for field in page.form.fields:
+                key = getattr(field.key, "text", "")
+                value = getattr(field.value, "text", "")
+                if key:
+                    fields[key] = value
+
+        return OCRResponse(form_name="", fields=fields)

--- a/tests/test_textract_service.py
+++ b/tests/test_textract_service.py
@@ -1,0 +1,108 @@
+from unittest.mock import MagicMock
+import sys
+import types
+import asyncio
+from io import BytesIO
+
+# Fake external modules before importing service
+fake_genai = MagicMock()
+fake_genai.types = MagicMock()
+google_pkg = types.ModuleType('google')
+google_pkg.generativeai = fake_genai
+sys.modules.setdefault('google', google_pkg)
+sys.modules.setdefault('google.generativeai', fake_genai)
+sys.modules.setdefault('google.generativeai.types', fake_genai.types)
+sys.modules.setdefault('magic', MagicMock())
+
+fake_boto3 = MagicMock()
+fake_client = MagicMock()
+fake_boto3.client.return_value = fake_client
+sys.modules['boto3'] = fake_boto3
+
+import importlib
+import services.ocr.textract.textract_service as textract_service_module
+importlib.reload(textract_service_module)
+import services.factory as factory_module
+importlib.reload(factory_module)
+
+from services.factory import get_ocr_service  # noqa: E402
+from services.ocr.textract.textract_service import TextractOCRService  # noqa: E402
+from services.ocr_processor import OCRProcessor  # noqa: E402
+from models import OCRResponse  # noqa: E402
+from fastapi import UploadFile  # noqa: E402
+from starlette.datastructures import Headers  # noqa: E402
+
+SAMPLE_RESPONSE = {
+    "Blocks": [
+        {"BlockType": "PAGE", "Id": "1", "Confidence": 99,
+         "Geometry": {"BoundingBox": {"Width": 1, "Height": 1, "Left": 0, "Top": 0}, "Polygon": []}},
+        {"BlockType": "WORD", "Id": "w1", "Text": "Nombre", "Confidence": 99,
+         "Geometry": {"BoundingBox": {"Width": 0.1, "Height": 0.1, "Left": 0, "Top": 0}, "Polygon": []}},
+        {"BlockType": "WORD", "Id": "w2", "Text": "Juan", "Confidence": 99,
+         "Geometry": {"BoundingBox": {"Width": 0.1, "Height": 0.1, "Left": 0.2, "Top": 0}, "Polygon": []}},
+        {"BlockType": "WORD", "Id": "w3", "Text": "Edad", "Confidence": 99,
+         "Geometry": {"BoundingBox": {"Width": 0.1, "Height": 0.1, "Left": 0.3, "Top": 0}, "Polygon": []}},
+        {"BlockType": "WORD", "Id": "w4", "Text": "30", "Confidence": 99,
+         "Geometry": {"BoundingBox": {"Width": 0.1, "Height": 0.1, "Left": 0.4, "Top": 0}, "Polygon": []}},
+        {"BlockType": "KEY_VALUE_SET", "Id": "kv1", "EntityTypes": ["KEY"], "Confidence": 99,
+         "Geometry": {"BoundingBox": {"Width": 0.1, "Height": 0.1, "Left": 0, "Top": 0}, "Polygon": []},
+         "Relationships": [{"Type": "VALUE", "Ids": ["kv2"]}, {"Type": "CHILD", "Ids": ["w1"]}]},
+        {"BlockType": "KEY_VALUE_SET", "Id": "kv2", "EntityTypes": ["VALUE"], "Confidence": 99,
+         "Geometry": {"BoundingBox": {"Width": 0.1, "Height": 0.1, "Left": 0.1, "Top": 0}, "Polygon": []},
+         "Relationships": [{"Type": "CHILD", "Ids": ["w2"]}]},
+        {"BlockType": "KEY_VALUE_SET", "Id": "kv3", "EntityTypes": ["KEY"], "Confidence": 99,
+         "Geometry": {"BoundingBox": {"Width": 0.1, "Height": 0.1, "Left": 0.3, "Top": 0}, "Polygon": []},
+         "Relationships": [{"Type": "VALUE", "Ids": ["kv4"]}, {"Type": "CHILD", "Ids": ["w3"]}]},
+        {"BlockType": "KEY_VALUE_SET", "Id": "kv4", "EntityTypes": ["VALUE"], "Confidence": 99,
+         "Geometry": {"BoundingBox": {"Width": 0.1, "Height": 0.1, "Left": 0.4, "Top": 0}, "Polygon": []},
+         "Relationships": [{"Type": "CHILD", "Ids": ["w4"]}]},
+    ],
+    "DocumentMetadata": {"Pages": 1},
+}
+
+
+def test_factory_returns_textract():
+    service = get_ocr_service("textract")
+    assert service.__class__.__name__ == "TextractOCRService"
+
+
+def test_textract_analyze(monkeypatch):
+    fake_client.analyze_document.return_value = SAMPLE_RESPONSE
+
+    service = TextractOCRService()
+
+    async def sync_to_thread(func, *a, **k):
+        return func(*a, **k)
+
+    monkeypatch.setattr(asyncio, "to_thread", sync_to_thread)
+
+    headers = Headers({"content-type": "application/pdf"})
+    upload = UploadFile(BytesIO(b"data"), filename="test.pdf", headers=headers)
+    result = asyncio.run(service.analyze(upload))
+
+    assert isinstance(result, OCRResponse)
+    assert result.fields == {"Nombre": "Juan", "Edad": "30"}
+    fake_client.analyze_document.assert_called()
+
+
+def test_processor_with_textract(monkeypatch):
+    fake_client.analyze_document.return_value = SAMPLE_RESPONSE
+    service = TextractOCRService()
+
+    def get_service(name=None):
+        return service
+
+    monkeypatch.setattr("services.ocr_processor.get_ocr_service", get_service)
+
+    async def sync_to_thread(func, *a, **k):
+        return func(*a, **k)
+
+    monkeypatch.setattr(asyncio, "to_thread", sync_to_thread)
+
+    headers = Headers({"content-type": "application/pdf"})
+    upload = UploadFile(BytesIO(b"data"), filename="test.pdf", headers=headers)
+
+    processor = OCRProcessor()
+    result = asyncio.run(processor.analyze(upload))
+
+    assert result == {"form_type": "", "fields": {"Nombre": "Juan", "Edad": "30"}}


### PR DESCRIPTION
## Summary
- add OCR service using Amazon Textract
- select OCR backend via `OCR_SERVICE` variable
- document new settings in README and `.env.example`
- include Amazon Textract parser dependency
- provide unit tests for the Textract service

## Testing
- `pytest -q`
- `pip install -r app/requirements.txt --quiet` *(fails: Operation cancelled by user)*

------
https://chatgpt.com/codex/tasks/task_e_686aba5389a0832280be49ba5821f0e9