### PR TITLE
Add JSON viewer for stored applications

### DIFF
--- a/web/static/applications.js
+++ b/web/static/applications.js
@@ -1,0 +1,22 @@
+function setupJsonModal() {
+    const modal = document.getElementById('json-modal');
+    if (!modal) return;
+    const closeBtn = document.getElementById('close-json');
+    if (closeBtn) {
+        closeBtn.onclick = () => { modal.style.display = 'none'; };
+    }
+    document.querySelectorAll('.json-btn').forEach(btn => {
+        btn.addEventListener('click', () => {
+            const pre = modal.querySelector('pre');
+            try {
+                const data = JSON.parse(btn.dataset.json);
+                pre.textContent = JSON.stringify(data, null, 2);
+            } catch (e) {
+                pre.textContent = btn.dataset.json;
+            }
+            modal.style.display = 'block';
+        });
+    });
+}
+
+document.addEventListener('DOMContentLoaded', setupJsonModal);

--- a/web/static/main.css
+++ b/web/static/main.css
@@ -144,3 +144,32 @@ th { background-color: #f5f5f5; }
     color: #721c24;
     border: 1px solid #f5c6cb;
 }
+
+#json-modal {
+    display: none;
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.5);
+    z-index: 1000;
+}
+
+#json-modal .content {
+    background: #fff;
+    margin: 5% auto;
+    padding: 1em;
+    width: 90%;
+    max-width: 600px;
+    max-height: 80%;
+    overflow: auto;
+    position: relative;
+    border-radius: 4px;
+}
+
+#json-modal .close-btn {
+    position: absolute;
+    top: 0.5em;
+    right: 0.5em;
+}

--- a/web/templates/applications.html
+++ b/web/templates/applications.html
@@ -12,29 +12,66 @@
 <table>
     <thead>
         <tr>
-            <th>ID</th>
-            <th>Fecha</th>
             <th>Tipo</th>
             <th>Nombre</th>
+            <th>Apellido paterno</th>
+            <th>Apellido materno</th>
+            <th>RFC</th>
+            <th>CURP</th>
+            <th>Email</th>
+            <th>Teléfono móvil</th>
+            <th>Teléfono casa</th>
+            <th>Fecha nacimiento</th>
+            <th>Monto solicitado</th>
+            <th>Ingresos mensuales</th>
+            <th>Riesgo score</th>
+            <th>Riesgo clase</th>
+            <th>Plazo crédito</th>
             <th>Status</th>
             <th>Documento</th>
+            <th>Datos</th>
         </tr>
     </thead>
     <tbody>
         {% for rec in records %}
         <tr>
-            <td>{{ rec.id }}</td>
-            <td>{{ rec.created_at.strftime('%Y-%m-%d') if rec.created_at }}</td>
             <td>{{ rec.tipo_credito }}</td>
-            <td>{{ rec.nombre }} {{ rec.apellido_paterno }}</td>
+            <td>{{ rec.nombre }}</td>
+            <td>{{ rec.apellido_paterno }}</td>
+            <td>{{ rec.apellido_materno }}</td>
+            <td>{{ rec.rfc }}</td>
+            <td>{{ rec.curp }}</td>
+            <td>{{ rec.email }}</td>
+            <td>{{ rec.telefono_movil }}</td>
+            <td>{{ rec.telecono_casa }}</td>
+            <td>{{ rec.fecha_nacimiento }}</td>
+            <td>{{ rec.monto_solicitado }}</td>
+            <td>{{ rec.ingresos_mensuales }}</td>
+            <td>{{ rec.riesgo_score }}</td>
+            <td>{{ rec.riesgo_clase }}</td>
+            <td>{{ rec.plazo_credito }}</td>
             <td>{{ rec.status }}</td>
             <td>
                 {% if rec.file_url %}
                     <a class="table-link" href="{{ rec.file_url }}" target="_blank">&#128196;</a>
                 {% endif %}
             </td>
+            <td>
+                <button type="button" class="json-btn" data-json='{{ rec.extra_data | tojson }}'>Ver</button>
+            </td>
         </tr>
         {% endfor %}
     </tbody>
 </table>
+
+<div id="json-modal">
+    <div class="content">
+        <button type="button" class="close-btn" id="close-json">Cerrar</button>
+        <pre></pre>
+    </div>
+</div>
+{% endblock %}
+
+{% block scripts %}
+    <script src="{{ url_for('static', filename='applications.js') }}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- display all saved fields for credit applications
- add button to view JSON data in modal popup
- style modal and add JS handler

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ae726f7cc832286dfaed7e8d19432