### PR TITLE
Fix saving of empty or formatted birth dates

### DIFF
--- a/app/services/utils/normalization.py
+++ b/app/services/utils/normalization.py
@@ -1,6 +1,7 @@
 import re
 import unicodedata
 from typing import Optional
+from datetime import datetime, date
 
 def normalize_key(key: str) -> str:
     """Normalize dictionary keys to snake_case."""
@@ -51,3 +52,22 @@ def parse_money(amount: str) -> Optional[str]:
         return f"{float(amt):.2f}"
     except ValueError:
         return None
+
+
+def parse_date(value: str) -> Optional[date]:
+    """Parse common date formats and return a ``date`` object.
+
+    Accepts ``dd/mm/aaaa``, ``dd-mm-aaaa`` and ``yyyy-mm-dd``. Returns ``None``
+    when the value cannot be parsed or is empty.
+    """
+
+    if not value:
+        return None
+
+    value = value.strip()
+    for fmt in ("%d/%m/%Y", "%d-%m-%Y", "%Y-%m-%d"):
+        try:
+            return datetime.strptime(value, fmt).date()
+        except ValueError:
+            continue
+    return None

--- a/web/services/db_client.py
+++ b/web/services/db_client.py
@@ -5,7 +5,7 @@ from sqlalchemy import create_engine, text
 from sqlalchemy.orm import sessionmaker, Session
 
 from services.utils.logger import get_logger
-from services.utils.normalization import normalize_key, parse_money
+from services.utils.normalization import normalize_key, parse_money, parse_date
 from services.db_models import Base, CreditApplication
 
 DEFAULT_DB_URL = "postgresql+psycopg2://user:password@db:5432/ocrdata"
@@ -95,7 +95,9 @@ class DatabaseClient:
                 or _extract(fields, "telefono_celular"),
                 telecono_casa=_extract(fields, "telecono_casa")
                 or _extract(fields, "telefono_casa"),
-                fecha_nacimiento=_extract(fields, "fecha_nacimiento"),
+                fecha_nacimiento=parse_date(
+                    _extract(fields, "fecha_nacimiento") or ""
+                ),
                 monto_solicitado=parse_money(
                     _extract(fields, "monto_solicitado")
                 ),

--- a/web/services/utils/normalization.py
+++ b/web/services/utils/normalization.py
@@ -1,6 +1,7 @@
 import re
 import unicodedata
 from typing import Optional
+from datetime import datetime, date
 
 def normalize_key(key: str) -> str:
     """Normalize dictionary keys to snake_case."""
@@ -51,3 +52,22 @@ def parse_money(amount: str) -> Optional[str]:
         return f"{float(amt):.2f}"
     except ValueError:
         return None
+
+
+def parse_date(value: str) -> Optional[date]:
+    """Parse common date formats and return a ``date`` object.
+
+    Accepts ``dd/mm/aaaa``, ``dd-mm-aaaa`` and ``yyyy-mm-dd``. Returns ``None``
+    when the value cannot be parsed or is empty.
+    """
+
+    if not value:
+        return None
+
+    value = value.strip()
+    for fmt in ("%d/%m/%Y", "%d-%m-%Y", "%Y-%m-%d"):
+        try:
+            return datetime.strptime(value, fmt).date()
+        except ValueError:
+            continue
+    return None


### PR DESCRIPTION
## Summary
- parse birth dates in both Flask and FastAPI util modules
- use `parse_date` when persisting applications

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ae9901cd88322a80e14e479f85975