### PR TITLE
Fix saving plazo_credito

### DIFF
--- a/tests/test_db_client.py
+++ b/tests/test_db_client.py
@@ -110,3 +110,21 @@ def test_money_fields_are_parsed(monkeypatch):
     assert kwargs["riesgo_score"] == "0.77"
 
 
+def test_plazo_credito_fallback(monkeypatch):
+    """plazo_credito uses plazo_meses or plazo_anios when provided."""
+    monkeypatch.setattr(DatabaseClient, "_ensure_columns", lambda self: None)
+    mock_model = MagicMock()
+    monkeypatch.setattr(db_client, "CreditApplication", mock_model)
+    db = DatabaseClient()
+    session_mock = MagicMock()
+    db.SessionLocal = MagicMock(return_value=session_mock)
+
+    fields = {"informacion_credito": {"plazo_meses": "12"}}
+    db.save_form("credito_personal", fields, None)
+    assert mock_model.call_args.kwargs["plazo_credito"] == "12"
+
+    fields = {"informacion_credito": {"plazo_anios": "8"}}
+    db.save_form("credito_hipotecario", fields, None)
+    assert mock_model.call_args.kwargs["plazo_credito"] == "8"
+
+

--- a/web/services/db_client.py
+++ b/web/services/db_client.py
@@ -104,7 +104,10 @@ class DatabaseClient:
                 ingresos_mensuales=parse_money(
                     _extract(fields, "ingresos_mensuales")
                 ),
-                plazo_credito=_extract(fields, "plazo_credito"),
+                plazo_credito=
+                    _extract(fields, "plazo_credito")
+                    or _extract(fields, "plazo_meses")
+                    or _extract(fields, "plazo_anios"),
                 riesgo_score=_extract(fields, "riesgo_score"),
                 riesgo_clase=_extract(fields, "riesgo_clase"),
                 extra_data=fields,


### PR DESCRIPTION
## Summary
- ensure DatabaseClient stores `plazo_credito` even when fields use `plazo_meses` or `plazo_anios`
- add unit tests for the new fallback logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686aede2af048322bb2ced47c9950136