### PR TITLE
Improve UI filtering and preview

### DIFF
--- a/web/app.py
+++ b/web/app.py
@@ -102,9 +102,9 @@ def save():
 @app.route("/applications", methods=["GET"])
 def list_applications():
     """Display stored credit applications."""
-    form_type = request.args.get("type", "credito_personal")
+    form_type = request.args.get("type")
     if form_type not in VALID_FORMS:
-        form_type = "credito_personal"
+        form_type = None
     records = db_client.list_applications(form_type)
     return render_template(
         "applications.html", records=records, form_type=form_type

--- a/web/services/db_client.py
+++ b/web/services/db_client.py
@@ -67,16 +67,14 @@ class DatabaseClient:
                 for stmt in statements:
                     conn.execute(text(stmt))
 
-    def list_applications(self, form_type: str = "credito_personal") -> list:
-        """Return stored credit applications for the given form type."""
+    def list_applications(self, form_type: Optional[str] = None) -> list:
+        """Return stored credit applications, optionally filtered by form type."""
         session: Session = self.SessionLocal()
         try:
-            return (
-                session.query(CreditApplication)
-                .filter(CreditApplication.tipo_credito == form_type)
-                .order_by(CreditApplication.id.desc())
-                .all()
-            )
+            query = session.query(CreditApplication)
+            if form_type:
+                query = query.filter(CreditApplication.tipo_credito == form_type)
+            return query.order_by(CreditApplication.id.desc()).all()
         finally:
             session.close()
 

--- a/web/static/main.css
+++ b/web/static/main.css
@@ -101,6 +101,13 @@ button {
 }
 
 .form-section, .preview-section { flex: 1; }
+.preview-section {
+    position: sticky;
+    top: 1em;
+    align-self: flex-start;
+    max-height: 90vh;
+    overflow: auto;
+}
 
 #image-container { overflow: hidden; cursor: grab; border: 1px solid #ccc; }
 #image-container img { transform-origin: top left; }

--- a/web/templates/applications.html
+++ b/web/templates/applications.html
@@ -4,8 +4,10 @@
 <h1>Solicitudes de Crédito</h1>
 <form method="get">
     <select name="type">
+        <option value="" {% if not form_type %}selected{% endif %}>Todos</option>
         <option value="credito_personal" {% if form_type=='credito_personal' %}selected{% endif %}>Crédito personal</option>
         <option value="credito_hipotecario" {% if form_type=='credito_hipotecario' %}selected{% endif %}>Crédito hipotecario</option>
+        <option value="credito_tarjeta" {% if form_type=='credito_tarjeta' %}selected{% endif %}>Tarjeta de crédito</option>
     </select>
     <button type="submit">Filtrar</button>
 </form>

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -14,10 +14,10 @@
         <div id="result-container" class="result-container" {% if not fields %}style="display:none;"{% endif %}>
             <div class="form-section">
                 <div id="spinner"></div>
-                <h2>Editar Datos</h2>
                 {% if form_type %}
-                <h3>{{ FORM_NAMES.get(form_type, form_type.replace('_', ' ').title()) }}</h3>
+                <h2>{{ FORM_NAMES.get(form_type, form_type.replace('_', ' ').title()) }}</h2>
                 {% endif %}
+                <h3>Editar Datos</h3>
                 <form id="edit-form" {% if not fields %}style="display:none;"{% endif %}>
                 <div id="form-area">
                 {% if fields %}


### PR DESCRIPTION
## Summary
- let `/applications` show all forms by default
- allow optional filter in `list_applications`
- make preview sticky when scrolling
- add `Tarjeta de crédito` and `Todos` filters
- show detected form name as section title

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686af69b833c83228fcb10d37e7d35fa