### PR TITLE
Fix file viewer support

### DIFF
--- a/tests/test_db_client.py
+++ b/tests/test_db_client.py
@@ -64,7 +64,7 @@ def test_casa_field(monkeypatch):
 
     db.save_form("credito_personal", {"telefono_casa": "123"}, None)
 
-    assert mock_model.call_args.kwargs["telecono_casa"] == "123"
+    assert mock_model.call_args.kwargs["telefono_casa"] == "123"
 
 
 def test_store_both_phone_numbers(monkeypatch):
@@ -81,7 +81,7 @@ def test_store_both_phone_numbers(monkeypatch):
 
     kwargs = mock_model.call_args.kwargs
     assert kwargs["telefono_movil"] == "777"
-    assert kwargs["telecono_casa"] == "555"
+    assert kwargs["telefono_casa"] == "555"
 
 
 def test_money_fields_are_parsed(monkeypatch):
@@ -126,5 +126,19 @@ def test_plazo_credito_fallback(monkeypatch):
     fields = {"informacion_credito": {"plazo_anios": "8"}}
     db.save_form("credito_hipotecario", fields, None)
     assert mock_model.call_args.kwargs["plazo_credito"] == "8"
+
+
+def test_save_file_url(monkeypatch):
+    """file_url is stored on the model when provided."""
+    monkeypatch.setattr(DatabaseClient, "_ensure_columns", lambda self: None)
+    mock_model = MagicMock()
+    monkeypatch.setattr(db_client, "CreditApplication", mock_model)
+    db = DatabaseClient()
+    session_mock = MagicMock()
+    db.SessionLocal = MagicMock(return_value=session_mock)
+
+    db.save_form("credito_personal", {}, "testurl")
+
+    assert mock_model.call_args.kwargs["file_url"] == "testurl"
 
 

--- a/web/services/db_client.py
+++ b/web/services/db_client.py
@@ -61,6 +61,8 @@ class DatabaseClient:
             statements.append(f"ALTER TABLE {table} ADD COLUMN telecono_casa VARCHAR")
         if "plazo_credito" not in columns:
             statements.append(f"ALTER TABLE {table} ADD COLUMN plazo_credito VARCHAR")
+        if "file_url" not in columns:
+            statements.append(f"ALTER TABLE {table} ADD COLUMN file_url VARCHAR")
 
         if statements:
             with self.engine.begin() as conn:
@@ -93,6 +95,7 @@ class DatabaseClient:
                 or _extract(fields, "telefono_celular"),
                 telefono_casa=_extract(fields, "telecono_casa")
                 or _extract(fields, "telefono_casa"),
+                file_url=file_url,
                 fecha_nacimiento=parse_date(
                     _extract(fields, "fecha_nacimiento") or ""
                 ),

--- a/web/services/db_models.py
+++ b/web/services/db_models.py
@@ -32,6 +32,7 @@ class CreditApplication(Base):
     email = Column(String)
     telefono_movil = Column(String)
     telefono_casa = Column(String)
+    file_url = Column(String)
     fecha_nacimiento = Column(Date)
     monto_solicitado = Column(Numeric(12, 2))
     ingresos_mensuales = Column(Numeric(12, 2))


### PR DESCRIPTION
## Summary
- store `file_url` in the `CreditApplication` table
- auto-create the column when missing
- persist the URL when saving applications
- update tests to cover the new field

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b01cb2a60832293fe90e1019b78ec