### PR TITLE
Add temporary OCR comparison controls

### DIFF
--- a/app/api/routes/analyze.py
+++ b/app/api/routes/analyze.py
@@ -1,14 +1,31 @@
-from fastapi import APIRouter, UploadFile, File, HTTPException
+from fastapi import APIRouter, UploadFile, File, HTTPException, Form
 from models.data_response import DataResponse
 from services.ocr_processor import OCRProcessor
 
 router = APIRouter()
-processor = OCRProcessor()
 
 
 @router.post("/analyze", response_model=DataResponse)
-async def analyze_document(file: UploadFile = File(...)):
+async def analyze_document(
+    file: UploadFile = File(...),
+    ocr_service: str | None = Form(None),
+    use_refiner: bool | None = Form(None),
+):
+    """Analyze a document using the selected OCR service.
+
+    This endpoint temporarily accepts ``ocr_service`` and ``use_refiner``
+    parameters so that the front-end can choose between Gemini and
+    Textract and optionally disable the refiner. Environment variables
+    remain the fallback configuration.
+    """
+
     if not file:
         raise HTTPException(status_code=400, detail="No file uploaded.")
+
+    processor = OCRProcessor(service_name=ocr_service, use_refiner=use_refiner)
     result = await processor.analyze(file)
-    return DataResponse(form_type=result["form_type"], filename=file.filename, fields=result["fields"])
+    return DataResponse(
+        form_type=result["form_type"],
+        filename=file.filename,
+        fields=result["fields"],
+    )

--- a/tests/test_gemini_service.py
+++ b/tests/test_gemini_service.py
@@ -143,3 +143,20 @@ def test_gemini_refine(monkeypatch):
 
     assert result == OCRResponse(form_name="credito", fields={"Nombre": "Ana"})
     mock_model.generate_content.assert_called()
+
+
+def test_processor_custom_refiner_choice(monkeypatch):
+    """Processor should respect the use_refiner flag."""
+    service = GeminiOCRService(api_key="key")
+
+    def get_service(name=None):
+        assert name == "gemini"
+        return service
+
+    monkeypatch.setattr("services.ocr_processor.get_ocr_service", get_service)
+
+    proc_no_refiner = OCRProcessor(service_name="gemini", use_refiner=False)
+    assert proc_no_refiner.refiner is None
+
+    proc_with_refiner = OCRProcessor(service_name="gemini", use_refiner=True)
+    assert isinstance(proc_with_refiner.refiner, GeminiRefinerService)

--- a/web/static/main.css
+++ b/web/static/main.css
@@ -34,6 +34,12 @@ form {
     margin-bottom: 2em;
 }
 
+.options {
+    margin-bottom: 0.5em;
+    display: flex;
+    gap: 1em;
+}
+
 input[type="file"] {
     margin: 0.5em 0;
 }

--- a/web/static/main.js
+++ b/web/static/main.js
@@ -136,6 +136,11 @@ function setupUploadForm() {
 
         const formData = new FormData();
         formData.append('file', file);
+        // Temporary options sent to the API: selected OCR backend and refiner flag
+        const serviceInput = uploadForm.querySelector('input[name="ocr_service"]:checked');
+        const useRefinerInput = uploadForm.querySelector('input[name="use_refiner"]');
+        if (serviceInput) formData.append('ocr_service', serviceInput.value);
+        if (useRefinerInput) formData.append('use_refiner', useRefinerInput.checked ? 'true' : 'false');
 
         try {
             const res = await fetch('http://localhost:8000/api/analyze', {

--- a/web/static/main.js
+++ b/web/static/main.js
@@ -111,6 +111,26 @@ function showPreview(file) {
 function setupUploadForm() {
     const uploadForm = document.getElementById('upload-form');
     if (!uploadForm) return;
+    const serviceRadios = uploadForm.querySelectorAll('input[name="ocr_service"]');
+    const refinerCheckbox = uploadForm.querySelector('input[name="use_refiner"]');
+    serviceRadios.forEach(r => {
+        r.addEventListener('change', () => {
+            if (r.checked && r.value === 'gemini') {
+                if (refinerCheckbox) {
+                    refinerCheckbox.checked = false;
+                    refinerCheckbox.disabled = true;
+                }
+            } else if (r.checked && r.value !== 'gemini') {
+                if (refinerCheckbox) refinerCheckbox.disabled = false;
+            }
+        });
+    });
+    // Apply initial state based on the default selection
+    const checkedRadio = uploadForm.querySelector('input[name="ocr_service"]:checked');
+    if (checkedRadio && checkedRadio.value === 'gemini' && refinerCheckbox) {
+        refinerCheckbox.checked = false;
+        refinerCheckbox.disabled = true;
+    }
     const fileInput = uploadForm.querySelector('input[name="document"]');
     fileInput.addEventListener('change', () => {
         if (!fileInput.files.length) return;

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -8,6 +8,12 @@
 {% block content %}
     <h1>Sube un documento de solicitud</h1>
     <form id="upload-form" action="/" method="post" enctype="multipart/form-data">
+        {# Temporary controls to compare OCR services and refiner usage #}
+        <div class="options">
+            <label><input type="radio" name="ocr_service" value="gemini" {% if ocr_default == 'gemini' %}checked{% endif %}> Gemini</label>
+            <label><input type="radio" name="ocr_service" value="textract" {% if ocr_default == 'textract' %}checked{% endif %}> Textract</label>
+            <label><input type="checkbox" name="use_refiner" checked> Usar refiner</label>
+        </div>
         <input type="file" name="document" accept="image/*,.pdf" required>
         <button type="submit">Enviar</button>
     </form>


### PR DESCRIPTION
## Summary
- allow overriding OCR backend and refiner usage via request params
- add OCR selection and refiner checkbox on upload form
- include selected options when calling the API
- expand tests for new processor options

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b078bf3b48322a1b3aac8b81238e9