### PR TITLE
Add OCR selection controls

### DIFF
--- a/app/api/routes/analyze.py
+++ b/app/api/routes/analyze.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, UploadFile, File, HTTPException
+from fastapi import APIRouter, UploadFile, File, HTTPException, Form
 from models.data_response import DataResponse
 from services.ocr_processor import OCRProcessor
 
@@ -7,8 +7,22 @@ processor = OCRProcessor()
 
 
 @router.post("/analyze", response_model=DataResponse)
-async def analyze_document(file: UploadFile = File(...)):
+async def analyze_document(
+    file: UploadFile = File(...),
+    ocr_service: str | None = Form(None),
+    use_refiner: bool | None = Form(None),
+):
+    """Analyze a document using the selected OCR backend."""
+
     if not file:
         raise HTTPException(status_code=400, detail="No file uploaded.")
-    result = await processor.analyze(file)
-    return DataResponse(form_type=result["form_type"], filename=file.filename, fields=result["fields"])
+
+    result = await processor.analyze(
+        file, ocr_service=ocr_service, use_refiner=use_refiner
+    )
+
+    return DataResponse(
+        form_type=result["form_type"],
+        filename=file.filename,
+        fields=result["fields"],
+    )

--- a/tests/test_textract_service.py
+++ b/tests/test_textract_service.py
@@ -186,3 +186,42 @@ def test_processor_with_textract(monkeypatch):
     fake_client.get_document_analysis.assert_called()
     fake_client.put_object.assert_called()
     fake_client.delete_object.assert_called()
+
+
+def test_processor_with_textract_no_refiner(monkeypatch):
+    """Refiner can be disabled via parameter."""
+    fake_client.start_document_analysis.return_value = {"JobId": "1"}
+    fake_client.get_document_analysis.return_value = {
+        "JobStatus": "SUCCEEDED",
+        **SAMPLE_RESPONSE,
+    }
+    service = TextractOCRService(bucket="bucket")
+
+    def get_service(name=None):
+        return service
+
+    monkeypatch.setattr("services.ocr_processor.get_ocr_service", get_service)
+
+    mock_refiner = MagicMock()
+    monkeypatch.setattr(
+        "services.ocr_processor.GeminiRefinerService", lambda *a, **k: mock_refiner
+    )
+
+    async def sync_to_thread(func, *a, **k):
+        return func(*a, **k)
+
+    monkeypatch.setattr(asyncio, "to_thread", sync_to_thread)
+
+    async def fake_sleep(*a, **k):
+        return None
+
+    monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+
+    headers = Headers({"content-type": "application/pdf"})
+    upload = UploadFile(BytesIO(b"data"), filename="test.pdf", headers=headers)
+
+    processor = OCRProcessor()
+    result = asyncio.run(processor.analyze(upload, use_refiner=False))
+
+    assert result == {"form_type": "", "fields": {"Nombre": "Juan", "Edad": "30"}}
+    mock_refiner.refine.assert_not_called()

--- a/web/static/main.js
+++ b/web/static/main.js
@@ -112,6 +112,24 @@ function setupUploadForm() {
     const uploadForm = document.getElementById('upload-form');
     if (!uploadForm) return;
     const fileInput = uploadForm.querySelector('input[name="document"]');
+    // Temporary controls for OCR comparison
+    const refinerCheckbox = uploadForm.querySelector('#use-refiner');
+    const ocrRadios = uploadForm.querySelectorAll('input[name="ocr_service"]');
+
+    function updateRefinerState() {
+        const selected = uploadForm.querySelector('input[name="ocr_service"]:checked');
+        if (selected && selected.value === 'gemini') {
+            if (refinerCheckbox) {
+                refinerCheckbox.checked = true;
+                refinerCheckbox.disabled = true;
+            }
+        } else if (refinerCheckbox) {
+            refinerCheckbox.disabled = false;
+        }
+    }
+
+    ocrRadios.forEach(r => r.addEventListener('change', updateRefinerState));
+    updateRefinerState();
     fileInput.addEventListener('change', () => {
         if (!fileInput.files.length) return;
         const file = fileInput.files[0];
@@ -136,6 +154,11 @@ function setupUploadForm() {
 
         const formData = new FormData();
         formData.append('file', file);
+        const selected = uploadForm.querySelector('input[name="ocr_service"]:checked');
+        if (selected) formData.append('ocr_service', selected.value);
+        if (refinerCheckbox) {
+            formData.append('use_refiner', refinerCheckbox.checked ? 'true' : 'false');
+        }
 
         try {
             const res = await fetch('http://localhost:8000/api/analyze', {

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -9,6 +9,21 @@
     <div class="card p-2 mb-4">
         <h1 class="h4 p-4 text-primary text-center">Sube un documento de solicitud</h1>
         <form id="upload-form" action="/" method="post" enctype="multipart/form-data" class="row g-3 align-items-end">
+            <!-- Opciones temporales para comparar OCR -->
+            <div class="col-12">
+                <div class="form-check form-check-inline">
+                    <input class="form-check-input" type="radio" name="ocr_service" id="ocr-gemini" value="gemini" checked>
+                    <label class="form-check-label" for="ocr-gemini">Gemini</label>
+                </div>
+                <div class="form-check form-check-inline">
+                    <input class="form-check-input" type="radio" name="ocr_service" id="ocr-textract" value="textract">
+                    <label class="form-check-label" for="ocr-textract">Textract</label>
+                </div>
+                <div class="form-check form-check-inline">
+                    <input class="form-check-input" type="checkbox" id="use-refiner" name="use_refiner" checked>
+                    <label class="form-check-label" for="use-refiner">Usar refiner</label>
+                </div>
+            </div>
             <div class="col-md-9">
                 <input class="form-control" type="file" name="document" accept="image/*,.pdf" required>
             </div>


### PR DESCRIPTION
## Summary
- expose parameters to choose OCR engine and disable refiner
- support runtime selection in `OCRProcessor`
- add radio buttons and checkbox in the web UI
- send chosen options via JavaScript
- cover optional refiner logic in tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b1a40461c8322a9a9c7e3bb7f8788