### PR TITLE
Fix file upload for mobile clients

### DIFF
--- a/web/static/main.js
+++ b/web/static/main.js
@@ -161,7 +161,8 @@ function setupUploadForm() {
         }
 
         try {
-            const res = await fetch('http://localhost:8000/api/analyze', {
+        const apiHost = `${window.location.protocol}//${window.location.hostname}:8000`;
+        const res = await fetch(`${apiHost}/api/analyze`, {
                 method: 'POST',
                 body: formData
             });


### PR DESCRIPTION
## Summary
- make API endpoint dynamic so the mobile UI works outside localhost

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686b245814d08322939270f99ff7861e