### PR TITLE
Fix field order in rendered forms

### DIFF
--- a/web/app.py
+++ b/web/app.py
@@ -11,6 +11,15 @@ logger = get_logger(__name__)
 logger.info("Starting Flask app...")
 db_client = DatabaseClient()
 
+
+@app.template_filter("ordered_items")
+def ordered_items(value):
+    """Return mapping items as a list to preserve order in templates."""
+    try:
+        return list(value.items())
+    except AttributeError:
+        return []
+
 VALID_FORMS = {"credito_personal", "credito_hipotecario", "credito_tarjeta"}
 
 

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -44,7 +44,7 @@
                 {% if fields %}
                     {% macro render_form(data, prefix='') %}
                     <div class="{{ 'subsection' if prefix }}">
-                        {% for key, value in data.items() %}
+                        {% for key, value in data|ordered_items %}
                             {% set field_name = (prefix ~ '.' if prefix else '') ~ key %}
                             {% if value is mapping %}
                                 <fieldset>


### PR DESCRIPTION
## Summary
- add custom `ordered_items` filter to Flask app
- use `ordered_items` in form-rendering template to preserve order

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686bdfb9965883228dfce133cc49e4a2